### PR TITLE
Changes

### DIFF
--- a/app/conex_author.ml
+++ b/app/conex_author.ml
@@ -111,7 +111,7 @@ let status _ path quorum id no_rec package =
         in
         Logs.app (fun m -> m "author %a %s (created %s) %a %d resources, %d queued"
                      Fmt.(styled `Bold pp_id) idx.Author.name
-                     (Header.counter idx.Author.counter idx.Author.wraps)
+                     (Header.counter idx.Author.counter idx.Author.epoch)
                      (Header.timestamp idx.Author.created)
                      Fmt.(styled style string) txt
                      (List.length idx.Author.resources)
@@ -292,12 +292,12 @@ let init _ dry path id email =
          List.sort_uniq Author.compare_account
            (`GitHub id :: List.map (fun e -> `Email e) email @ idx.Author.accounts)
        and counter = idx.Author.counter
-       and wraps = idx.Author.wraps
+       and epoch = idx.Author.epoch
        and queued = idx.Author.queued
        and resources = idx.Author.resources
        and created = idx.Author.created
        in
-       let idx = Author.t ~accounts ~counter ~wraps ~resources ~queued created id in
+       let idx = Author.t ~accounts ~counter ~epoch ~resources ~queued created id in
        let approve idx typ wire =
          let counter = Author.next_id idx in
          let digest = V.digest wire in

--- a/src/conex_crypto.ml
+++ b/src/conex_crypto.ml
@@ -17,7 +17,7 @@ let pp_verification_error ppf = function
 module type VERIFY_BACK = sig
   val verify_rsa_pss : key:string -> data:string -> signature:string -> (unit, [> verification_error ]) result
 
-  val b64sha256 : string -> string
+  val sha256 : string -> string
 end
 
 module type VERIFY = sig
@@ -33,10 +33,9 @@ end
 (** Instantiation. *)
 module Make_verify (C : VERIFY_BACK) = struct
 
-  let raw_digest data = `SHA256, C.b64sha256 data
+  let raw_digest data = `SHA256, C.sha256 data
 
-  let digest data =
-    raw_digest (Wire.to_string data)
+  let digest data = raw_digest (Wire.to_string data)
 
   let keyid id k = digest (Key.wire id k)
 

--- a/src/conex_crypto.mli
+++ b/src/conex_crypto.mli
@@ -44,9 +44,9 @@ module type VERIFY_BACK = sig
   val verify_rsa_pss : key:string -> data:string -> signature:string ->
     (unit, [> verification_error ]) result
 
-  (** [b64sha356 str] computes the SHA256 digest of [str] and converts it to
-      base64. *)
-  val b64sha256 : string -> string
+  (** [sha356 str] computes the SHA256 digest of [str] and converts it to
+      hex. *)
+  val sha256 : string -> string
 end
 
 (** Instantiation. *)

--- a/src/conex_io.mli
+++ b/src/conex_io.mli
@@ -45,14 +45,14 @@ type cc_err = [ `FileNotFound of name | `NotADirectory of name ]
 (** [pp_cc_err] is a pretty printer for {!cc_err}. *)
 val pp_cc_err : cc_err fmt
 
-(** [compute_release digestf t now name] computes the release by computing
+(** [compute_checksums digestf t now name] computes the release by computing
     checksums of all files and directories of [name] using [digestf].  If
     release [name] is not found, an error is signalled. *)
-val compute_release : (string -> Digest.t) -> t -> Uint.t -> name -> (Release.t, cc_err) result
+val compute_checksums : (string -> Digest.t) -> t -> Uint.t -> name -> (Checksums.t, cc_err) result
 
-(** [compute_package t create name] computes the package by listing all
+(** [compute_releases t create name] computes the package by listing all
     subdirectories of [name]. *)
-val compute_package : t -> Uint.t -> name -> (Package.t, string) result
+val compute_releases : t -> Uint.t -> name -> (Releases.t, string) result
 
 
 (** {1 Reading of resource files} *)
@@ -78,13 +78,13 @@ val read_team : t -> identifier -> (Team.t, [> r_err ]) result
     [name] on [t]. *)
 val read_authorisation : t -> name -> (Authorisation.t, [> r_err ]) result
 
-(** [read_package t name] reads and parses the package for the given
+(** [read_releases t name] reads and parses the package for the given
     [name] on [t]. *)
-val read_package : t -> name -> (Package.t, [> r_err ]) result
+val read_releases : t -> name -> (Releases.t, [> r_err ]) result
 
-(** [read_release t name.version] reads and parses the release for the given
+(** [read_checksums t name.version] reads and parses the release for the given
     [name.version] on [t]. *)
-val read_release : t -> name -> (Release.t, [> r_err ]) result
+val read_checksums : t -> name -> (Checksums.t, [> r_err ]) result
 
 (** {1 Writing of resources to files} *)
 
@@ -97,8 +97,8 @@ val write_team : t -> Team.t -> (unit, string) result
 (** [write_authorisation t a] writes the given authorisation on [t]. *)
 val write_authorisation : t -> Authorisation.t -> (unit, string) result
 
-(** [write_package t p] writes the given package on [t]. *)
-val write_package : t -> Package.t -> (unit, string) result
+(** [write_releases t p] writes the given releases on [t]. *)
+val write_releases : t -> Releases.t -> (unit, string) result
 
-(** [write_release t r] writes the given release on [t]. *)
-val write_release : t -> Release.t -> (unit, string) result
+(** [write_checksums t r] writes the given checksums on [t]. *)
+val write_checksums : t -> Checksums.t -> (unit, string) result

--- a/src/conex_opam_encoding.ml
+++ b/src/conex_opam_encoding.ml
@@ -14,7 +14,8 @@ let rec encode_s = function
       in
       OpamParserTypes.List (np, data)
   | Wire.List l -> OpamParserTypes.List (np, List.map encode_s l)
-  | Wire.String s -> OpamParserTypes.String (np, s)
+  | Wire.Identifier i -> OpamParserTypes.Ident (np, i)
+  | Wire.Data s -> OpamParserTypes.String (np, s)
   | Wire.Int i -> OpamParserTypes.Ident (np, "0x" ^ Uint.to_string i)
 
 let encode t =
@@ -37,8 +38,8 @@ let rec decode_s = function
     else if data = "emptymap" then
       Ok (Wire.Map M.empty)
     else
-      Error "unexpected ident"
-  | OpamParserTypes.String (_, s) -> Ok (Wire.String (String.trim s))
+      Ok (Wire.Identifier data)
+  | OpamParserTypes.String (_, s) -> Ok (Wire.Data (String.trim s))
   | OpamParserTypes.List (_, []) -> Ok (Wire.List [])
   | OpamParserTypes.List (_, l) ->
     let is_pair = function

--- a/src/conex_opam_encoding.ml
+++ b/src/conex_opam_encoding.ml
@@ -9,7 +9,7 @@ let rec encode_s = function
       OpamParserTypes.Ident (np, "emptymap")
     else
       let data = M.fold (fun k v acc ->
-          OpamParserTypes.(List (np, [ String (np, k) ; encode_s v ])) :: acc)
+          OpamParserTypes.(List (np, [ Ident (np, k) ; encode_s v ])) :: acc)
           s []
       in
       OpamParserTypes.List (np, data)
@@ -42,14 +42,14 @@ let rec decode_s = function
   | OpamParserTypes.List (_, []) -> Ok (Wire.List [])
   | OpamParserTypes.List (_, l) ->
     let is_pair = function
-        OpamParserTypes.List (_, [OpamParserTypes.String _ ; _]) -> true
+      | OpamParserTypes.List (_, [OpamParserTypes.Ident _ ; _]) -> true
       | _ -> false
     in
     if List.for_all is_pair l then begin
       List.fold_left (fun m xs ->
           m >>= fun m ->
           match xs with
-            OpamParserTypes.List (_, [ OpamParserTypes.String (_, k) ; v ]) ->
+            OpamParserTypes.List (_, [ OpamParserTypes.Ident (_, k) ; v ]) ->
             (decode_s v >>= fun v -> Ok (M.add (String.trim k) v m))
           | _ -> Error "can not happen")
         (Ok M.empty) l >>= fun map ->

--- a/src/conex_opam_repository_layout.ml
+++ b/src/conex_opam_repository_layout.ml
@@ -22,23 +22,23 @@ let authorisation_filename = "authorisation"
 
 let authorisation_path id = [ data_dir ; id ; authorisation_filename ]
 
-let package_filename = "package"
-let package_path id = [ data_dir ; id ; package_filename ]
+let releases_filename = "releases"
+let package_path id = [ data_dir ; id ; releases_filename ]
 
-let release_filename = "release"
+let checksums_filename = "checksums"
 
 let release_dir p =
   match authorisation_of_package p with
   | Some d -> [ data_dir ; d ; p ]
   | None -> [ data_dir ; p ; p ]
 
-let release_path p =
-  release_dir p @ [release_filename]
+let checksums_path p =
+  release_dir p @ [checksums_filename]
 
 let categorise = function
   | idx ::id :: [] when idx = id_dir -> `Id id
   | dd :: id :: dfn :: [] when dd = data_dir && dfn = authorisation_filename -> `Authorisation id
-  | dd :: id :: dfn :: [] when dd = data_dir && dfn = package_filename -> `Package id
+  | dd :: id :: dfn :: [] when dd = data_dir && dfn = releases_filename -> `Package id
   | dd :: id :: dfn :: _ when dd = data_dir ->
     (* current: packages/foo/foo.0.0.1 *)
     (match authorisation_of_package dfn with

--- a/src/conex_opam_repository_layout.mli
+++ b/src/conex_opam_repository_layout.mli
@@ -34,19 +34,19 @@ val id_file : identifier -> path
     for [name] is stored.  Currently [data_dir; name; "authorisation"]. *)
 val authorisation_path : name -> path
 
-(** [package_path name] is the full path where the "package" file for [name] is
-    stored.  Currently [data_dir; name; "package"]. *)
+(** [package_path name] is the full path where the "releases" file for [name] is
+    stored.  Currently [data_dir; name; "releases"]. *)
 val package_path : name -> path
 
-(** [release_filename] is "release". *)
-val release_filename : name
+(** [checksums_filename] is "checksums". *)
+val checksums_filename : name
 
 (** [release_dir name] is [data_dir;] {!authorisation_of_package} (if [None],
     [name]), followed by [name]. *)
 val release_dir : name -> path
 
-(** [release_path name] is [release_dir @ release_filename]. *)
-val release_path : name -> path
+(** [checksums_path name] is [release_dir @ checksums_filename]. *)
+val checksums_path : name -> path
 
 (** [categorise path] identifies which resource owns the given [path]. *)
 val categorise : path -> [ `Id of identifier

--- a/src/conex_repository.mli
+++ b/src/conex_repository.mli
@@ -22,9 +22,9 @@
     {- {!validate_team} is successful if approved by a quorum of janitors}
     {- {!validate_authorisation} is successful if approved by a quorum of
        janitors}
-    {- {!validate_package} is successful if approved by an authorised author OR
+    {- {!validate_releases} is successful if approved by an authorised author OR
        a quorum of janitors}
-    {- {!validate_release} is successful if approved by an authorised author OR a
+    {- {!validate_checksums} is successful if approved by an authorised author OR a
        quorum of janitors}}
 
     Monotonicity requirements are as follows:
@@ -35,9 +35,9 @@
        supported (a team may have no members)}
     {- {!monoton_authorisation} requires the counter to increase, deletion is
        not supported}
-    {- {!monoton_package} requires the counter to increase, deletion is not
+    {- {!monoton_releases} requires the counter to increase, deletion is not
        supported (the list of releases can be empty)}
-    {- {!monoton_release} requires the counter to increase}}
+    {- {!monoton_checksums} requires the counter to increase}}
 
 *)
 
@@ -113,7 +113,7 @@ val pp_error :
   | `InvalidReleases of name * S.t * S.t
   | `NoSharedPrefix of name * S.t
   | `NotInReleases of name * S.t
-  | `ChecksumsDiff of name * name list * name list * (Release.c * Release.c) list ]
+  | `ChecksumsDiff of name * name list * name list * (Checksums.c * Checksums.c) list ]
     fmt
 
 (** [validate_author repo author] validates [author]: at least one public key
@@ -158,27 +158,27 @@ val validate_authorisation : t -> Authorisation.t ->
    | `InsufficientQuorum of name * typ * S.t * int
    | `IdNotPresent of name * S.t ]) result
 
-(** [validate_package repo ~on_disk auth package] validates [package]: an
+(** [validate_releases repo ~on_disk auth releases] validates [releases]: an
     {!authorised} identity must approve the package in [repo], all releases must
     be prefixed with the package name, and if [on_disk] is given, the list of
     releases have to be identical. *)
-val validate_package : t -> ?on_disk:Package.t -> Authorisation.t -> Package.t ->
+val validate_releases : t -> ?on_disk:Releases.t -> Authorisation.t -> Releases.t ->
   ([ `Approved of identifier | `Quorum of S.t | `Both of identifier * S.t ],
    [> base_error
    | `AuthRelMismatch of name * name
    | `InvalidReleases of name * S.t * S.t
    | `NoSharedPrefix of name * S.t ]) result
 
-(** [validate_release repo ~on_disk auth package release] validates [release]:
+(** [validate_checksums repo ~on_disk auth releases checksums] validates [checksums]:
     an {!authorised} (using [auth]) identity must approve the release in [repo],
     it must be part of the releases of [package], and if [on_disk] is given,
     the files listed must be equal, as well as their checksums.  *)
-val validate_release : t -> ?on_disk:Release.t -> Authorisation.t -> Package.t -> Release.t ->
+val validate_checksums : t -> ?on_disk:Checksums.t -> Authorisation.t -> Releases.t -> Checksums.t ->
   ([ `Approved of identifier | `Quorum of S.t | `Both of identifier * S.t ],
    [> base_error
    | `AuthRelMismatch of name * name
    | `NotInReleases of name * S.t
-   | `ChecksumsDiff of name * name list * name list * (Release.c * Release.c) list ]) result
+   | `ChecksumsDiff of name * name list * name list * (Checksums.c * Checksums.c) list ]) result
 
 (** {1 Monotonicity} *)
 
@@ -201,11 +201,11 @@ val monoton_team : ?old:Team.t -> ?now:Team.t -> t -> (unit, m_err) result
 (** [monoton_authorisation ~old ~now repo] checks that the counter increased. *)
 val monoton_authorisation : ?old:Authorisation.t -> ?now:Authorisation.t -> t -> (unit, m_err) result
 
-(** [monoton_package ~old ~now repo] checks that the counter increased. *)
-val monoton_package : ?old:Package.t -> ?now:Package.t -> t -> (unit, m_err) result
+(** [monoton_releases ~old ~now repo] checks that the counter increased. *)
+val monoton_releases : ?old:Releases.t -> ?now:Releases.t -> t -> (unit, m_err) result
 
-(** [monoton_release ~old ~now repo] checks that the counter increased. *)
-val monoton_release : ?old:Release.t -> ?now:Release.t -> t -> (unit, m_err) result
+(** [monoton_checksums ~old ~now repo] checks that the counter increased. *)
+val monoton_checksums : ?old:Checksums.t -> ?now:Checksums.t -> t -> (unit, m_err) result
 
 (** {1 Unsafe operations} *)
 

--- a/src/conex_resource.mli
+++ b/src/conex_resource.mli
@@ -5,7 +5,7 @@
     type, a counter, an epoch, and a creation timestamp.  There are
     broadly three kinds of resources: those containing identities ({!Team} and
     {!Author}), those regulating access to packages ({!Authorisation}), and
-    those with the digests of the opam repository data ({!Package} and
+    those with the digests of the opam repository data ({!Releases} and
     {!Release}).
 *)
 
@@ -67,8 +67,8 @@ type typ = [
   | `Epoch
   | `Team
   | `Authorisation
-  | `Package
-  | `Release
+  | `Releases
+  | `Checksums
 ]
 
 (** [resource_to_string res] is the string representation of [res]. *)
@@ -423,19 +423,19 @@ module Authorisation : sig
   val prep : t -> t * bool
 end
 
-(** {1 Package} *)
+(** {1 Releases} *)
 
-(** A package lists all releases of a given package.  There is one package
-    resource for each package. *)
-module Package : sig
+(** A releases lists all released versions of a given package.  There is one
+    releases resource for each package. *)
+module Releases : sig
 
-  (** The record for a package: a header, and a set of release names. *)
+  (** The record for a releases: a header, and a set of version names. *)
   type t = private {
     created : Uint.t ;
     counter : Uint.t ;
     epoch : Uint.t ;
     name : name ;
-    releases : S.t ;
+    versions : S.t ;
   }
 
   (** [pp] is a pretty printer. *)
@@ -443,21 +443,21 @@ module Package : sig
 
   (** [t ~counter ~epoch ~releases created name] is a constructor. *)
   val t : ?counter:Uint.t -> ?epoch:Uint.t ->
-    ?releases:S.t -> Uint.t -> name -> t
+    ?versions:S.t -> Uint.t -> name -> t
 
-  (** [equal t t'] is true if the names are equal and the set of releases. *)
+  (** [equal t t'] is true if the names are equal and the set of versions. *)
   val equal : t -> t -> bool
 
-  (** [of_wire w] converts [w] to a package or error. *)
+  (** [of_wire w] converts [w] to a releases or error. *)
   val of_wire : Wire.t -> (t, string) result
 
   (** [wire t] is the wire representation of [t], as stored on disk. *)
   val wire : t -> Wire.t
 
-  (** [add t name] adds [name] to [t.releases]. *)
+  (** [add t name] adds [name] to [t.versions]. *)
   val add : t -> name -> t
 
-  (** [remove t name] removes [name] from [t.releases]. *)
+  (** [remove t name] removes [name] from [t.versions]. *)
   val remove : t -> name -> t
 
   (** [prep t] increments [t.counter], the carry bit is returned as second
@@ -465,11 +465,11 @@ module Package : sig
   val prep : t -> t * bool
 end
 
-(** {1 Release} *)
+(** {1 Checksums} *)
 
-(** A release contains a map of all files in the repository relevant for this
-    release and their digests. *)
-module Release : sig
+(** A checksums contains a map of all files in the repository relevant for this
+    package version and their digests. *)
+module Checksums : sig
 
   (** The record for a checksum: filename and digest. *)
   type c = {
@@ -487,7 +487,7 @@ module Release : sig
   (** Type of a checksum map. *)
   type checksum_map
 
-  (** The record of a release: a header, and a checksum map. *)
+  (** The record of checksums: a header, and a checksum map. *)
   type t = private {
     created : Uint.t ;
     counter : Uint.t ;
@@ -502,7 +502,7 @@ module Release : sig
   (** [t ~counter ~epoch created name checksums] is a constructor. *)
   val t : ?counter:Uint.t -> ?epoch:Uint.t -> Uint.t -> string -> c list -> t
 
-  (** [of_wire w] converts [w] to a release or error. *)
+  (** [of_wire w] converts [w] to a checksums or error. *)
   val of_wire : Wire.t -> (t, string) result
 
   (** [wire t] is the wire representation of [t]. *)

--- a/src/conex_resource.mli
+++ b/src/conex_resource.mli
@@ -39,12 +39,13 @@ val id_equal : identifier -> identifier -> bool
     computations, and persistent storage on disk. *)
 module Wire : sig
 
-  (** The values in the key value store: either a map, a list, a string, or an
-      unsigned integer. *)
+  (** The values in the key value store: either a map, a list, an identifier,
+      data (represented as string), or an unsigned integer. *)
   type s =
     | Map of s M.t
     | List of s list
-    | String of string
+    | Identifier of identifier
+    | Data of string
     | Int of Uint.t
 
   (** The toplevel node, a Map *)
@@ -89,7 +90,7 @@ val typ_of_wire : Wire.s -> (typ, string) result
 (** Common header on disk *)
 module Header : sig
 
-  (** The header consists of version, created, counter, epoch, a name, and a typ. *)
+  (** The header consists of version, created, counter, epoch, name, and typ. *)
   type t = {
     version : Uint.t ;
     created : Uint.t ;

--- a/src/conex_resource.mli
+++ b/src/conex_resource.mli
@@ -2,7 +2,7 @@
 
     Every resource in conex is a piece of data (or metadata), and has its own
     purpose.  Resources stored on disk consists of a common header: a name, a
-    type, a counter, a wraparound counter, and a creation timestamp.  There are
+    type, a counter, an epoch, and a creation timestamp.  There are
     broadly three kinds of resources: those containing identities ({!Team} and
     {!Author}), those regulating access to packages ({!Authorisation}), and
     those with the digests of the opam repository data ({!Package} and
@@ -64,7 +64,7 @@ type typ = [
   | `Key
   | `Account
   | `Author
-  | `Wrap
+  | `Epoch
   | `Team
   | `Authorisation
   | `Package
@@ -89,12 +89,12 @@ val typ_of_wire : Wire.s -> (typ, string) result
 (** Common header on disk *)
 module Header : sig
 
-  (** The header consists of version, created, counter, wraps, a name, and a typ. *)
+  (** The header consists of version, created, counter, epoch, a name, and a typ. *)
   type t = {
     version : Uint.t ;
     created : Uint.t ;
     counter : Uint.t ;
-    wraps : Uint.t ;
+    epoch : Uint.t ;
     name : name ;
     typ : typ
   }
@@ -112,8 +112,8 @@ module Header : sig
       seconds since UNIX epoch). *)
   val timestamp : Uint.t -> string
 
-  (** [counter ctr wrap] prints [ctr, wrap] to a string containing the counter
-      and wraps (unless zero). *)
+  (** [counter ctr epoch] prints [ctr, epoch] to a string containing the counter
+      and epoch (unless zero). *)
   val counter : Uint.t -> Uint.t -> string
 end
 
@@ -273,7 +273,7 @@ module Author : sig
     (* signed part *)
     created : Uint.t ;
     counter : Uint.t ;
-    wraps : Uint.t ;
+    epoch : Uint.t ;
     name : identifier ;
     resources : r list ;
     (* unsigned part *)
@@ -285,9 +285,9 @@ module Author : sig
   (** [pp] is a pretty printer. *)
   val pp : t fmt
 
-  (** [t ~counter ~wraps ~accounts ~keys ~resources ~queued created name] is a
+  (** [t ~counter ~epoch ~accounts ~keys ~resources ~queued created name] is a
       constructor. *)
-  val t : ?counter:Uint.t -> ?wraps:Uint.t ->
+  val t : ?counter:Uint.t -> ?epoch:Uint.t ->
     ?accounts:(account list) ->
     ?keys:((Key.t * Signature.t) list) ->
     ?resources:(r list) ->
@@ -346,7 +346,7 @@ module Team : sig
   type t = private {
     created : Uint.t ;
     counter : Uint.t ;
-    wraps : Uint.t ;
+    epoch : Uint.t ;
     name : identifier ;
     members : S.t
   }
@@ -354,8 +354,8 @@ module Team : sig
   (** [pp] is a pretty printer. *)
   val pp : t fmt
 
-  (** [t ~counter ~wraps ~members created id] is a constructor for a team. *)
-  val t : ?counter:Uint.t -> ?wraps:Uint.t ->
+  (** [t ~counter ~epoch ~members created id] is a constructor for a team. *)
+  val t : ?counter:Uint.t -> ?epoch:Uint.t ->
     ?members:S.t -> Uint.t -> identifier -> t
 
   (** [equal t t'] is true if the set of members is equal and the name is
@@ -390,7 +390,7 @@ module Authorisation : sig
   type t = private {
     created : Uint.t ;
     counter : Uint.t ;
-    wraps : Uint.t ;
+    epoch : Uint.t ;
     name : name ;
     authorised : S.t ;
   }
@@ -398,8 +398,8 @@ module Authorisation : sig
   (** [pp] is a pretty printer. *)
   val pp : t fmt
 
-  (** [t ~counter ~wraps ~authorised created name] is a constructor. *)
-  val t : ?counter:Uint.t -> ?wraps:Uint.t ->
+  (** [t ~counter ~epoch ~authorised created name] is a constructor. *)
+  val t : ?counter:Uint.t -> ?epoch:Uint.t ->
     ?authorised:S.t -> Uint.t -> name -> t
 
   (** [equal t t'] is true if the names are equal and the set of authorised ids
@@ -433,7 +433,7 @@ module Package : sig
   type t = private {
     created : Uint.t ;
     counter : Uint.t ;
-    wraps : Uint.t ;
+    epoch : Uint.t ;
     name : name ;
     releases : S.t ;
   }
@@ -441,8 +441,8 @@ module Package : sig
   (** [pp] is a pretty printer. *)
   val pp : t fmt
 
-  (** [t ~counter ~wraps ~releases created name] is a constructor. *)
-  val t : ?counter:Uint.t -> ?wraps:Uint.t ->
+  (** [t ~counter ~epoch ~releases created name] is a constructor. *)
+  val t : ?counter:Uint.t -> ?epoch:Uint.t ->
     ?releases:S.t -> Uint.t -> name -> t
 
   (** [equal t t'] is true if the names are equal and the set of releases. *)
@@ -491,7 +491,7 @@ module Release : sig
   type t = private {
     created : Uint.t ;
     counter : Uint.t ;
-    wraps : Uint.t ;
+    epoch : Uint.t ;
     name : name ;
     files : checksum_map ;
   }
@@ -499,8 +499,8 @@ module Release : sig
   (** [pp] is a pretty printer. *)
   val pp : t fmt
 
-  (** [t ~counter ~wraps created name checksums] is a constructor. *)
-  val t : ?counter:Uint.t -> ?wraps:Uint.t -> Uint.t -> string -> c list -> t
+  (** [t ~counter ~epoch created name checksums] is a constructor. *)
+  val t : ?counter:Uint.t -> ?epoch:Uint.t -> Uint.t -> string -> c list -> t
 
   (** [of_wire w] converts [w] to a release or error. *)
   val of_wire : Wire.t -> (t, string) result

--- a/src/nocrypto/conex_nocrypto.ml
+++ b/src/nocrypto/conex_nocrypto.ml
@@ -27,11 +27,29 @@ module V = struct
           Error `InvalidSignature
       | _ -> Error `InvalidPublicKey
 
-  let b64sha256 data =
+  let to_h i =
+    if i < 10 then
+      char_of_int (0x30 + i)
+    else
+      char_of_int (0x57 + i)
+
+  let to_hex cs =
+    let l = Cstruct.len cs in
+    let out = Bytes.create (2 * l) in
+    for i = 0 to pred l do
+      let b = Cstruct.get_uint8 cs i in
+      let up = b lsr 4
+      and low = b land 0x0F
+      in
+      Bytes.set out (i * 2) (to_h up);
+      Bytes.set out (i * 2 + 1) (to_h low);
+    done;
+    Bytes.to_string out
+
+  let sha256 data =
     let cs = Cstruct.of_string data in
     let check = Nocrypto.Hash.digest `SHA256 cs in
-    let b64 = Nocrypto.Base64.encode check in
-    Cstruct.to_string b64
+    to_hex check
 end
 
 module C = struct

--- a/src/openssl/conex_openssl.ml
+++ b/src/openssl/conex_openssl.ml
@@ -124,11 +124,11 @@ module V = struct
     | Error x when x = "broken" -> Error `InvalidSignature
     | Error _ -> Error `InvalidPublicKey
 
-  let b64sha256 data =
+  let sha256 data =
     match
       let filename = Filename.temp_file "conex" "b64" in
       Conex_unix_persistency.write_replace filename data >>= fun () ->
-      let cmd = Printf.sprintf "openssl dgst -binary -sha256 %s | openssl base64" filename in
+      let cmd = Printf.sprintf "openssl dgst -hex -r -sha256 %s | cut -d ' ' -f 1" filename in
       let input = Unix.open_process_in cmd in
       let output = input_line input in
       let _ = Unix.close_process_in input in

--- a/test/common.ml
+++ b/test/common.ml
@@ -86,23 +86,23 @@ let auth =
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)
 
-let package =
+let rels =
   let module M = struct
-    type t = Package.t
-    let pp = Package.pp
+    type t = Releases.t
+    let pp = Releases.pp
     let equal a b =
-      let open Package in
+      let open Releases in
       a.counter = b.counter &&
       a.name = b.name &&
-      S.equal a.releases b.releases
+      S.equal a.versions b.versions
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)
 
-let rel =
+let css =
   let module M = struct
-    type t = Release.t
-    let pp = Release.pp
-    let equal a b = match Release.compare_t a b with Ok () -> true | _ -> false
+    type t = Checksums.t
+    let pp = Checksums.pp
+    let equal a b = match Checksums.compare_t a b with Ok () -> true | _ -> false
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)
 

--- a/test/repositorytests.ml
+++ b/test/repositorytests.ml
@@ -350,20 +350,20 @@ let basic_persistency () =
   let bad_n =
     M.add "name" (String "foo") bad_n
   in
-  Alcotest.check (result team str_err) "couldn't parse team (type, wraps missing)"
+  Alcotest.check (result team str_err) "couldn't parse team (type, epoch missing)"
     (Error "") (Team.of_wire bad_n) ;
   let bad_n =
     M.add "typ" (Int Uint.zero) bad_n
   in
-  Alcotest.check (result team str_err) "couldn't parse team (bad type, wraps missing)"
+  Alcotest.check (result team str_err) "couldn't parse team (bad type, epoch missing)"
     (Error "") (Team.of_wire bad_n) ;
   let bad_n =
     M.add "typ" (String "team") bad_n
   in
-  Alcotest.check (result team str_err) "couldn't parse team (wraps missing)"
+  Alcotest.check (result team str_err) "couldn't parse team (epoch missing)"
     (Error "") (Team.of_wire bad_n) ;
   let good_n =
-    M.add "wraps" (Int Uint.zero) (M.add "created" (Int Uint.zero) bad_n)
+    M.add "epoch" (Int Uint.zero) (M.add "created" (Int Uint.zero) bad_n)
   in
   let t = Team.t Uint.zero "foo" in
   Alcotest.check (result team str_err) "could parse team"
@@ -397,14 +397,14 @@ let basic_persistency () =
     (Ok t) (Conex_opam_encoding.decode (Conex_opam_encoding.encode (Team.wire t)) >>= Team.of_wire) ;
   let checksum =
     List [
-      String "sha256=cd63ec5f833d1a4daebd8d098358404906bdca2083539fc6913264ef06ea13a6" ;
-      String "foo"
+      String "foo" ;
+      String "sha256=16fb0f83c716a73bb95a726e414408510a5e1de5673c9a44f9032655fd865daf"
     ]
   in
   let css =
     M.add "name" (String "foo")
       (M.add "counter" (Int Uint.zero)
-         (M.add "wraps" (Int Uint.zero)
+         (M.add "epoch" (Int Uint.zero)
             (M.add "created" (Int Uint.zero)
                (M.add "version" (Int Uint.zero)
                   (M.add "typ" (String "release")
@@ -426,7 +426,7 @@ let basic_persistency () =
     M.add "name" (String "foo")
       (M.add "counter" (Int Uint.zero)
          (M.add "created" (Int Uint.zero)
-            (M.add "wraps" (Int Uint.zero)
+            (M.add "epoch" (Int Uint.zero)
                (M.add "typ" (String "author")
                   (M.add "version" (Int Uint.zero) M.empty)))))
   in

--- a/test/repositorytests.ml
+++ b/test/repositorytests.ml
@@ -329,7 +329,7 @@ let basic_persistency () =
   Alcotest.check (result digest str_err) "couldn't parse digest"
     (Error "") (Digest.of_wire (List [ String "bar" ; Int Uint.zero ])) ;
   Alcotest.check (result digest str_err) "could parse digest"
-    (Ok (`SHA256, "1234")) (Digest.of_wire (List [ String "SHA256" ; String "1234" ])) ;
+    (Ok (`SHA256, "1234")) (Digest.of_wire (String "sha256=1234")) ;
   let bad_key = List [Int Uint.zero ; String "foo" ; String "bar"] in
   Alcotest.check (result key str_err) "couldn't parse key"
     (Error "") (Key.of_wire bad_key) ;
@@ -397,7 +397,7 @@ let basic_persistency () =
     (Ok t) (Conex_opam_encoding.decode (Conex_opam_encoding.encode (Team.wire t)) >>= Team.of_wire) ;
   let checksum =
     List [
-      List [ String "SHA256" ; String "zWPsX4M9Gk2uvY0Jg1hASQa9yiCDU5/GkTJk7wbqE6Y=" ] ;
+      String "sha256=cd63ec5f833d1a4daebd8d098358404906bdca2083539fc6913264ef06ea13a6" ;
       String "foo"
     ]
   in
@@ -447,7 +447,8 @@ let basic_persistency () =
     M.add "index" (Int Uint.zero)
       (M.add "name" (String "foobar")
          (M.add "typ" (String "team")
-            (M.add "digest" (List [ String "SHA256" ; String "01234567890123456789012345678901234567890123" ]) M.empty)))
+            (M.add "digest" (String "sha256=01234567890123456789012345678901234567890123")
+               M.empty)))
   in
   let r' = Author.r Uint.zero "foobar" `Team (`SHA256, "01234567890123456789012345678901234567890123") in
   let idx = M.add "resources" (List [ Map r ]) idx in

--- a/test/repositorytests.ml
+++ b/test/repositorytests.ml
@@ -310,33 +310,41 @@ let basic_persistency () =
   Alcotest.check (result team str_err) "couldn't parse team"
     (Error "") (Team.of_wire M.empty) ;
   Alcotest.check (result typ str_err) "couldn't parse typ"
-    (Error "") (typ_of_wire (String "frabs")) ;
+    (Error "") (typ_of_wire (Identifier "frabs")) ;
+  Alcotest.check (result typ str_err) "couldn't parse typ"
+    (Error "") (typ_of_wire (Data "key")) ;
   Alcotest.check (result typ str_err) "couldn't parse typ"
     (Error "") (typ_of_wire (Int Uint.zero)) ;
   Alcotest.check (result signature str_err) "couldn't parse signature"
-    (Error "") (Signature.of_wire (List [ Int Uint.zero ; String "foo" ; String "baz" ])) ;
+    (Error "") (Signature.of_wire (List [ Int Uint.zero ; Data "foo" ; Data "baz" ])) ;
   Alcotest.check (result signature str_err) "couldn't parse signature"
-    (Error "") (Signature.of_wire (List [ String "foo" ; String "foo" ; Int Uint.zero ])) ;
+    (Error "") (Signature.of_wire (List [ Int Uint.zero ; Identifier "foo" ; Data "baz" ])) ;
+  Alcotest.check (result signature str_err) "couldn't parse signature"
+    (Error "") (Signature.of_wire (List [ Int Uint.zero ; Data "foo" ; Identifier "baz" ])) ;
+  Alcotest.check (result signature str_err) "couldn't parse signature"
+    (Error "") (Signature.of_wire (List [ Int Uint.zero ; Identifier "foo" ; Identifier "baz" ])) ;
+  Alcotest.check (result signature str_err) "couldn't parse signature"
+    (Error "") (Signature.of_wire (List [ Data "foo" ; Identifier "foo" ; Int Uint.zero ])) ;
   Alcotest.check (result signature str_err) "couldn't parse signature"
     (Error "") (Signature.of_wire (List [ Int Uint.zero ; Int Uint.zero ; Int Uint.zero ])) ;
   Alcotest.check (result signature str_err) "could parse signature"
     (Ok ((`RSA_PSS_SHA256, Uint.zero), "frab"))
-    (Signature.of_wire (List [ Int Uint.zero ; String "RSA-PSS-SHA256" ; String "frab" ])) ;
+    (Signature.of_wire (List [ Int Uint.zero ; Identifier "RSA-PSS-SHA256" ; Data "frab" ])) ;
   Alcotest.check (result digest str_err) "couldn't parse digest"
-    (Error "") (Digest.of_wire (List [ Int Uint.zero ; String "foobar" ])) ;
+    (Error "") (Digest.of_wire (List [ Int Uint.zero ; Data "foobar" ])) ;
   Alcotest.check (result digest str_err) "couldn't parse digest"
-    (Error "") (Digest.of_wire (List [ String "bar" ; String "foobar" ])) ;
+    (Error "") (Digest.of_wire (List [ Data "bar" ; Data "foobar" ])) ;
   Alcotest.check (result digest str_err) "couldn't parse digest"
-    (Error "") (Digest.of_wire (List [ String "bar" ; Int Uint.zero ])) ;
+    (Error "") (Digest.of_wire (List [ Data "bar" ; Int Uint.zero ])) ;
   Alcotest.check (result digest str_err) "could parse digest"
-    (Ok (`SHA256, "1234")) (Digest.of_wire (String "sha256=1234")) ;
-  let bad_key = List [Int Uint.zero ; String "foo" ; String "bar"] in
+    (Ok (`SHA256, "1234")) (Digest.of_wire (Data "sha256=1234")) ;
+  let bad_key = List [Int Uint.zero ; Data "foo" ; Data "bar"] in
   Alcotest.check (result key str_err) "couldn't parse key"
     (Error "") (Key.of_wire bad_key) ;
-  let bad_key = List [String "foobar" ; String "foo" ; Int Uint.zero] in
+  let bad_key = List [Data "foobar" ; Data "foo" ; Int Uint.zero] in
   Alcotest.check (result key str_err) "couldn't parse key (bad typ)"
     (Error "") (Key.of_wire bad_key) ;
-  let bad_c = M.add "counter" (String "foo") M.empty in
+  let bad_c = M.add "counter" (Data "foo") M.empty in
   Alcotest.check (result team str_err) "couldn't parse team counter"
     (Error "") (Team.of_wire bad_c) ;
   let bad_n =
@@ -348,7 +356,7 @@ let basic_persistency () =
   Alcotest.check (result team str_err) "couldn't parse team name"
     (Error "") (Team.of_wire bad_n) ;
   let bad_n =
-    M.add "name" (String "foo") bad_n
+    M.add "name" (Data "foo") bad_n
   in
   Alcotest.check (result team str_err) "couldn't parse team (type, epoch missing)"
     (Error "") (Team.of_wire bad_n) ;
@@ -358,7 +366,7 @@ let basic_persistency () =
   Alcotest.check (result team str_err) "couldn't parse team (bad type, epoch missing)"
     (Error "") (Team.of_wire bad_n) ;
   let bad_n =
-    M.add "typ" (String "team") bad_n
+    M.add "typ" (Identifier "team") bad_n
   in
   Alcotest.check (result team str_err) "couldn't parse team (epoch missing)"
     (Error "") (Team.of_wire bad_n) ;
@@ -368,25 +376,25 @@ let basic_persistency () =
   let t = Team.t Uint.zero "foo" in
   Alcotest.check (result team str_err) "could parse team"
     (Ok t) (Team.of_wire good_n) ;
-  let bad_n = M.add "typ" (String "author") good_n in
+  let bad_n = M.add "typ" (Identifier "author") good_n in
   Alcotest.check (result team str_err) "couldn't parse team (wrong typ)"
     (Error "") (Team.of_wire bad_n) ;
   let bad_n = M.add "version" (Int Uint.(of_int_exn 23)) good_n in
   Alcotest.check (result team str_err) "couldn't parse team (wrong version)"
     (Error "") (Team.of_wire bad_n) ;
   let bad_m =
-    M.add "members" (String "bl") good_n
+    M.add "members" (Data "bl") good_n
   in
   Alcotest.check (result team str_err) "couldn't parse team members"
     (Error "") (Team.of_wire bad_m) ;
   let bad_m =
     M.add "members" (List [ Int Uint.zero ])
-      (M.add "name" (String "foo") good_n)
+      (M.add "name" (Identifier "foo") good_n)
   in
   Alcotest.check (result team str_err) "couldn't parse team members (not a set)"
     (Error "") (Team.of_wire bad_m) ;
   let good_t =
-    M.add "members" (List [ String "foo" ]) good_n
+    M.add "members" (List [ Data "foo" ]) good_n
   in
   let t = Team.t ~members:(S.singleton "foo") Uint.zero "foo" in
   Alcotest.check (result team str_err) "could parse team"
@@ -397,17 +405,17 @@ let basic_persistency () =
     (Ok t) (Conex_opam_encoding.decode (Conex_opam_encoding.encode (Team.wire t)) >>= Team.of_wire) ;
   let checksum =
     List [
-      String "foo" ;
-      String "sha256=16fb0f83c716a73bb95a726e414408510a5e1de5673c9a44f9032655fd865daf"
+      Data "foo" ;
+      Data "sha256=3234c3275955af97d5def935a26098933c303f02813497d6b96d6aef9afe362f"
     ]
   in
   let css' =
-    M.add "name" (String "foo")
+    M.add "name" (Data "foo")
       (M.add "counter" (Int Uint.zero)
          (M.add "epoch" (Int Uint.zero)
             (M.add "created" (Int Uint.zero)
                (M.add "version" (Int Uint.zero)
-                  (M.add "typ" (String "checksums")
+                  (M.add "typ" (Identifier "checksums")
                      (M.add "files" (List [checksum]) M.empty))))))
   in
   let csum =
@@ -418,16 +426,16 @@ let basic_persistency () =
   Alcotest.check (result css str_err) "can parse checksum"
     (Ok csums) (Checksums.of_wire css') ;
 
-  let s = List [ Int Uint.zero ; String (Signature.alg_to_string `RSA_PSS_SHA256) ; String "barf" ] in
-  let pub = List [ String "RSA" ; String "data" ; Int Uint.zero ] in
+  let s = List [ Int Uint.zero ; Identifier (Signature.alg_to_string `RSA_PSS_SHA256) ; Data "barf" ] in
+  let pub = List [ Identifier "RSA" ; Data "data" ; Int Uint.zero ] in
   let pub' = (`RSA, "data", Uint.zero) in
   let s' = ((`RSA_PSS_SHA256, Uint.zero), "frab") in
   let idx =
-    M.add "name" (String "foo")
+    M.add "name" (Data "foo")
       (M.add "counter" (Int Uint.zero)
          (M.add "created" (Int Uint.zero)
             (M.add "epoch" (Int Uint.zero)
-               (M.add "typ" (String "author")
+               (M.add "typ" (Identifier "author")
                   (M.add "version" (Int Uint.zero) M.empty)))))
   in
   let empty_idx =
@@ -445,9 +453,9 @@ let basic_persistency () =
     (Ok idx') (Author.of_wire (Author.wire idx')) ;
   let r =
     M.add "index" (Int Uint.zero)
-      (M.add "name" (String "foobar")
-         (M.add "typ" (String "team")
-            (M.add "digest" (String "sha256=01234567890123456789012345678901234567890123")
+      (M.add "name" (Data "foobar")
+         (M.add "typ" (Identifier "team")
+            (M.add "digest" (Data "sha256=01234567890123456789012345678901234567890123")
                M.empty)))
   in
   let r' = Author.r Uint.zero "foobar" `Team (`SHA256, "01234567890123456789012345678901234567890123") in
@@ -460,7 +468,7 @@ let basic_persistency () =
     (Ok idx') (Author.of_wire idxs) ;
   Alcotest.check (result ji str_err) "can unparse/parse index"
     (Ok idx') (Author.of_wire (Author.wire idx')) ;
-  let bad_r = M.add "typ" (String "teamfoo") r in
+  let bad_r = M.add "typ" (Identifier "teamfoo") r in
   let idx = M.add "resources" (List [ Map bad_r ]) idx in
   let idxs =
     M.add "signed" (Map idx) empty_idx

--- a/test/repositorytests.ml
+++ b/test/repositorytests.ml
@@ -261,12 +261,12 @@ let checks_r () =
     (Ok ()) (io.write ["packages"; "foo"; "foo.0"; "files"; "patch1"] "p1") ;
   Alcotest.check (result Alcotest.unit str_err) "writing 'p2' to 'packages/foo/foo.0/files/patch2'"
     (Ok ()) (io.write ["packages"; "foo"; "foo.0"; "files"; "patch2"] "p2") ;
-  (* manually crafted using echo -n XXX | openssl dgst -sha256 -binary | b64encode -m - *)
+  (* manually crafted using echo -n XXX | openssl dgst -sha256 -hex *)
   let csums = [
-    { Release.filename = "bar" ; digest = (`SHA256, "LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=") } ;
-    { Release.filename = "foo" ; digest = (`SHA256, "/N4rLtula/QIYB+3If6bXDONEO5CnqBPrlURto+/j7k=") } ;
-    { Release.filename = "files/patch1" ; digest = (`SHA256, "9kVR/NbweCPLh5cc+5FEZCXaGChrOrHvk14MvXpp9oo=") } ;
-    { Release.filename = "files/patch2" ; digest = (`SHA256, "OUbKZP942TymEJCkN8u2s9LKDUiPX5zPMFlgg2iydpM=") }
+    { Release.filename = "bar" ; digest = (`SHA256, "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae") } ;
+    { Release.filename = "foo" ; digest = (`SHA256, "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9") } ;
+    { Release.filename = "files/patch1" ; digest = (`SHA256, "f64551fcd6f07823cb87971cfb91446425da18286b3ab1ef935e0cbd7a69f68a") } ;
+    { Release.filename = "files/patch2" ; digest = (`SHA256, "3946ca64ff78d93ca61090a437cbb6b3d2ca0d488f5f9ccf3059608368b27693") }
   ]
   in
   let css = Release.t Uint.zero "foo.0" csums in
@@ -1527,10 +1527,10 @@ let cs_bad () =
     (Ok ()) (io.write ["packages"; pname; v; "files"; "patch2"] "p2") ;
   (* manually crafted using echo -n XXX | openssl dgst -sha256 -binary | b64encode -m - *)
   let csums = [
-    { Release.filename = "bar" ; digest = (`SHA256, "LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=") } ;
-    { Release.filename = "foo" ; digest = (`SHA256, "/N4rLtula/QIYB+3If6bXDONEO5CnqBPrlURto+/j7k=") } ;
-    { Release.filename = "files/patch1" ; digest = (`SHA256, "9kVR/NbweCPLh5cc+5FEZCXaGChrOrHvk14MvXpp9oo=") } ;
-    { Release.filename = "files/patch2" ; digest = (`SHA256, "OUbKZP942TymEJCkN8u2s9LKDUiPX5zPMFlgg2iydpM=") }
+    { Release.filename = "bar" ; digest = (`SHA256, "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae") } ;
+    { Release.filename = "foo" ; digest = (`SHA256, "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9") } ;
+    { Release.filename = "files/patch1" ; digest = (`SHA256, "f64551fcd6f07823cb87971cfb91446425da18286b3ab1ef935e0cbd7a69f68a") } ;
+    { Release.filename = "files/patch2" ; digest = (`SHA256, "3946ca64ff78d93ca61090a437cbb6b3d2ca0d488f5f9ccf3059608368b27693") }
   ]
   in
   let css = Release.t Uint.zero v csums in


### PR DESCRIPTION
these are changes requested by @AltGr (see #10).  They break all currently deployed conex instances (by using other file names and a different wire format).  Luckily we can ignore the currently deployed conex installations :)