### PR TITLE
package into two packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ script: bash -ex .travis-opam.sh
 sudo: required
 env:
   global:
-    - PACKAGE="conex"
+    - PINS="conex:. conex-nocrypto:."
   matrix:
-    - OCAML_VERSION=4.03
-    - OCAML_VERSION=4.04
+    - OCAML_VERSION=4.03 PACKAGE="conex"
+    - OCAML_VERSION=4.04 PACKAGE="conex"
+    - OCAML_VERSION=4.05 PACKAGE="conex"
+    - OCAML_VERSION=4.03 PACKAGE="conex-nocrypto"
+    - OCAML_VERSION=4.04 PACKAGE="conex-nocrypto"
 notifications:
   email: false

--- a/_tags
+++ b/_tags
@@ -13,6 +13,3 @@ true : warn(+A-4-33-44-48-58)
 
 <test/*.{ml,byte,native}>: package(alcotest)
 <test/tests.{ml,native}>: package(cstruct nocrypto x509 nocrypto.unix opam-file-format)
-
-<analysis/opam_repo_stats.{ml,native}>: package(cstruct nocrypto x509 astring opam-file-format logs)
-<analysis/maintainer.{ml,native}>: package(cstruct nocrypto x509 astring opam-file-format opam-format logs cmdliner logs.cli logs.fmt fmt)

--- a/analysis/_tags
+++ b/analysis/_tags
@@ -1,0 +1,2 @@
+<opam_repo_stats.{ml,native}>: package(cstruct nocrypto x509 astring opam-file-format logs)
+<maintainer.{ml,native}>: package(cstruct nocrypto x509 astring opam-file-format opam-format logs cmdliner logs.cli logs.fmt fmt)

--- a/conex-nocrypto.opam
+++ b/conex-nocrypto.opam
@@ -9,15 +9,27 @@ maintainer:   ["Hannes Mehnert <hannes@mehnert.org>"]
 license:      "BSD2"
 
 build: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+  [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" "%{name}%"
+    "--pinned" "%{pinned}%" "--tests" "false" ]
+]
+
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" "%{name}%" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" "--pkg-name" "%{name}%" ]
 ]
 
 depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build}
+  "alcotest"   {test}
   "cmdliner"
+  "conex"
   "opam-file-format" {>= "2.0.0~beta"}
+  "cstruct"    {>= "1.6.0"}
+  "nocrypto"   {>= "0.5.4"}
+  "x509"       {>= "0.4.0"}
+  "logs" "fmt" "rresult"
 ]
 
 available: [ ocaml-version >= "4.03.0" ]

--- a/pkg/META
+++ b/pkg/META
@@ -5,14 +5,3 @@ archive(byte) = "conex.cma"
 archive(native) = "conex.cmxa"
 plugin(byte) = "conex.cma"
 plugin(native) = "conex.cmxs"
-
-package "nocrypto" (
-  description = "Sign and verify provider based on nocrypto"
-  version = "%%VERSION_NUM%%"
-  requires = "nocrypto x509 cstruct"
-  archive(byte) = "conex-nocrypto.cma"
-  archive(native) = "conex-nocrypto.cmxa"
-  plugin(byte) = "conex-nocrypto.cma"
-  plugin(native) = "conex-nocrypto.cmxs"
-  exists_if = "conex-nocrypto.cma"
-)

--- a/pkg/META.nocrypto
+++ b/pkg/META.nocrypto
@@ -1,0 +1,8 @@
+description = "Sign and verify provider based on nocrypto"
+version = "%%VERSION_NUM%%"
+requires = "nocrypto x509 cstruct logs fmt rresult"
+archive(byte) = "conex-nocrypto.cma"
+archive(native) = "conex-nocrypto.cmxa"
+plugin(byte) = "conex-nocrypto.cma"
+plugin(native) = "conex-nocrypto.cmxs"
+exists_if = "conex-nocrypto.cma"


### PR DESCRIPTION
- one being `conex` itself, which depends only on cmdliner and opam-file-format (both are parts of opam), and provides `conex_verify_openssl`.  I suspect the build system needs to be revised (using a shell script?) to get rid of ocamlfind + ocamlbuild dependencies (need suggestions)
- the other is `conex-nocrypto`, which includes `conex_author` and `conex_verify_nocrypto`

the tests are only built with the latter, not the former.  travis is adapted to pin both packages and build both (4.05.0 cannot install nocrypto atm due to some dependencies (ppx_deriving) not being installable)