### PR TITLE
Snapshot service

### DIFF
--- a/_tags
+++ b/_tags
@@ -10,6 +10,7 @@ true : warn(+A-4-33-44-48-58)
 <app/*.{ml,native}>: package(cmdliner opam-file-format unix)
 <app/conex_author.{ml,native}>: package(cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult)
 <app/conex_verify_nocrypto.{ml,native}>: package(cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult)
+<app/conex_snapshot.{ml,native}>: package(cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult)
 
 <test/*.{ml,byte,native}>: package(alcotest)
 <test/tests.{ml,native}>: package(cstruct nocrypto x509 nocrypto.unix opam-file-format)

--- a/app/conex_snapshot.ml
+++ b/app/conex_snapshot.ml
@@ -1,0 +1,94 @@
+open Conex_utils
+open Conex_resource
+open Rresult
+
+module V = Conex_nocrypto.NC_V
+module C = Conex.Make(Logs)(V)
+module PRIV = Conex_private.Make(Conex_nocrypto.C(Conex_unix_private_key))
+
+let queue_r idx name auth =
+  let counter = Author.next_id idx in
+  let data = Author.wire auth in
+  let digest = V.digest data in
+  let res = Author.r counter name `Author digest in
+  Logs.info (fun m -> m "added %a to queue" Author.pp_r res) ;
+  let idx = Author.queue idx res in
+  Author.approve idx res
+
+let now = match Uint.of_float (Unix.time ()) with
+  | None -> invalid_arg "cannot convert now to unsigned integer"
+  | Some x -> x
+
+let err_to_cmdliner = function
+  | Ok _ -> `Ok ()
+  | Error m -> `Error (false, m)
+
+let doit _ repo quorum patchfile ignore_missing id =
+  err_to_cmdliner (
+    (match patchfile with
+     | None -> Error "you have to provide --patch"
+     | Some p -> Ok p) >>= fun patchfile ->
+    Nocrypto_entropy_unix.initialize () ;
+    (match id with
+     | None -> Error "you have to provide --id"
+     | Some id -> PRIV.read id >>= fun p -> (Ok (id, p))) >>= fun (id, priv) ->
+    Conex_unix_provider.fs_provider repo >>= fun io ->
+    let repo = Conex_repository.repository ?quorum V.digest () in
+    Conex_unix_persistency.read_file patchfile >>= fun patch ->
+    C.verify_diff ~ignore_missing io repo patch >>= fun _ ->
+    let ws = Logs.warn_count () in
+    Printf.printf "verification successfull with %d warnings\n" ws ;
+    let diffs = Conex_diff.to_diffs patch in
+    let newio = List.fold_left Conex_diff_provider.apply io diffs in
+    (* now that we have a sane repository, read ourselves, increment counter,
+       sign, and save... we expect patch to not include us *)
+    let idx = match Conex_io.read_author io id with
+      | Ok idx -> idx (* should empty all the resources - no need for keeping old stuff *)
+      | Error _ -> Author.t Uint.zero id
+    in
+    (* sign _all_ the (new)authors (apart from ourselves/other snaps and potential
+       timestamps -- does it hurt?) *)
+    Conex_io.ids newio >>= fun ids ->
+    (* we ignore errors in this fold: verify above already complained, and we're
+       not signing off any teams! *)
+    let idx = S.fold (fun id idx ->
+        match Conex_io.read_author newio id with
+        | Ok data -> queue_r idx id data
+        | _ -> idx)
+        ids idx
+    in
+    PRIV.sign now idx `RSA_PSS_SHA256 priv >>= fun idx ->
+    Logs.info (fun m -> m "signed author %a" Author.pp idx) ;
+    Conex_io.write_author io idx >>| fun () ->
+    Logs.app (fun m -> m "wrote %s to disk" id))
+
+let setup_log style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.set_level level;
+  Logs.set_reporter (Logs_fmt.reporter ~dst:Format.std_formatter ())
+
+open Conex_opts
+open Cmdliner
+
+let setup_log =
+  Term.(const setup_log
+        $ Fmt_cli.style_renderer ~docs ()
+        $ Logs_cli.level ~docs ())
+
+let repo =
+  let doc = "Repository base directory" in
+  Arg.(value & pos 0 dir "" & info [] ~docs ~doc)
+
+let man = [
+  `S "DESCRIPTION" ;
+  `P "$(tname) snapshots a given repository"
+]
+
+let cmd =
+  Term.(ret (const doit $ setup_log $ repo $ quorum $ patch $ no_strict $ id)),
+  Term.info "conex_snapshot" ~version:"%%VERSION_NUM%%"
+    ~doc:"Snapshot a given repository" ~man
+
+
+let () =
+  match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/app/conex_verify_app.ml
+++ b/app/conex_verify_app.ml
@@ -70,21 +70,19 @@ module VERIFY (L : LOGS) (V : Conex_verify.S) = struct
 
 
   let verify_it repodir quorum anchors incremental dir patch nostrict =
-    err_to_cmdliner
-      (let ta = Conex_opts.convert_anchors anchors in
-       Conex_openssl.V.check_version () >>= fun () ->
-       let repo = Conex_repository.repository ?quorum Conex_openssl.O_V.digest () in
-       match repodir, incremental, patch, dir with
-       | Some repodir, true, Some p, None ->
-         Conex_unix_provider.fs_ro_provider repodir >>= fun io ->
-         L.debug (fun m -> m "repository %a" Conex_io.pp io) ;
-         verify_patch io repo p nostrict
-       | _, false, None, Some d ->
-         Conex_unix_provider.fs_ro_provider d >>= fun io ->
-         L.debug (fun m -> m "repository %a" Conex_io.pp io) ;
-         verify_full io repo ta nostrict
-       | None, _, _, _ -> Error "--repo is required"
-       | _ -> Error "invalid combination of incremental, patch and dir")
+    let ta = Conex_opts.convert_anchors anchors in
+    let repo = Conex_repository.repository ?quorum V.digest () in
+    match repodir, incremental, patch, dir with
+    | Some repodir, true, Some p, None ->
+      Conex_unix_provider.fs_ro_provider repodir >>= fun io ->
+      L.debug (fun m -> m "repository %a" Conex_io.pp io) ;
+      verify_patch io repo p nostrict
+    | _, false, None, Some d ->
+      Conex_unix_provider.fs_ro_provider d >>= fun io ->
+      L.debug (fun m -> m "repository %a" Conex_io.pp io) ;
+      verify_full io repo ta nostrict
+    | None, _, _, _ -> Error "--repo is required"
+    | _ -> Error "invalid combination of incremental, patch and dir"
 end
 
 let doc = "Verify a signed community repository"

--- a/app/conex_verify_nocrypto.ml
+++ b/app/conex_verify_nocrypto.ml
@@ -1,8 +1,9 @@
-open Conex_utils
+open Conex_verify_app
 
-module V = Conex_verify_app.VERIFY (Logs) (Conex_nocrypto.NC_V)
+module V = VERIFY(Logs)(Conex_nocrypto.NC_V)
 
-let jump _ = V.verify_it
+let jump _ repo quorum anchors inc dir patch nostrict =
+  err_to_cmdliner (V.verify_it repo quorum anchors inc dir patch nostrict)
 
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();

--- a/app/conex_verify_openssl.ml
+++ b/app/conex_verify_openssl.ml
@@ -67,7 +67,8 @@ module Log : EXTLOGS = struct
   let warn ?src:_ msgf = incr wcount ; kmsg kunit `Warn msgf
 end
 
-module V = Conex_verify_app.VERIFY (Log) (Conex_openssl.O_V)
+open Conex_verify_app
+module V = VERIFY(Log)(Conex_openssl.O_V)
 
 let terminal () =
   let dumb = try Sys.getenv "TERM" = "dumb" with
@@ -88,7 +89,9 @@ let setup repo quorum anchors incremental dir patch verbose quiet strict no_c =
   let styled = if no_c then false else match terminal () with `Ansi_tty -> true | `None -> false
   in
   Log.set_styled styled ;
-  V.verify_it repo quorum anchors incremental dir patch strict
+  err_to_cmdliner (
+    Conex_openssl.V.check_version () >>= fun () ->
+    V.verify_it repo quorum anchors incremental dir patch strict)
 
 open Conex_opts
 open Cmdliner

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -31,6 +31,7 @@ let () =
          Pkg.mllib "src/nocrypto/conex-nocrypto.mllib" ;
          Pkg.bin "app/conex_author" ;
          Pkg.bin "app/conex_verify_nocrypto" ;
+         Pkg.bin "app/conex_snapshot" ;
          Pkg.test "test/tests" ]
   | other ->
     R.error_msgf "unknown package name: %s" other

--- a/src/conex.ml
+++ b/src/conex.ml
@@ -194,9 +194,7 @@ module Make (L : LOGS) (C : Conex_verify.S) = struct
     let janitor_keys =
       S.fold (fun id acc ->
           match IO.read_author io id with
-          | Ok idx ->
-            let id (k, _) = C.keyid id k in
-            List.map id idx.Author.keys @ acc
+          | Ok idx -> List.map (fun (k,_) -> C.keyid id k) idx.Author.keys @ acc
           | Error _ -> acc)
         (match find_team repo "janitors" with None -> S.empty | Some x -> x)
         []

--- a/src/conex.ml
+++ b/src/conex.ml
@@ -158,6 +158,15 @@ module Make (L : LOGS) (C : Conex_verify.S) = struct
           (S.elements rel.Releases.versions) >>= fun () ->
         Ok repo
 
+  let verify_snapshot io repo =
+    let snap = "snapshot" in
+    to_str IO.pp_r_err (IO.read_author io snap) >>= fun idx ->
+    IO.ids io >>= fun ids ->
+    to_str IO.pp_r_err (foldS (fun acc id ->
+        IO.read_author io id >>= fun idx ->
+        Ok (idx :: acc)) [] (S.remove snap ids)) >>= fun idxs ->
+    validate_snapshot repo idxs idx
+
     (* we could try to be more smart:
        - only check all modified authorisations, releases, packages
        --> but if a team is modified, or an index is modified (add/remove!), we
@@ -185,22 +194,12 @@ module Make (L : LOGS) (C : Conex_verify.S) = struct
        packages/foo/authorisation (maybe empty)
        packages/foo/releases <- empty
 *)
-  let verify_patch ?ignore_missing repo io newio (ids, auths, rels, check) =
+  let verify_patch ?ignore_missing ?(valid = fun _ _ -> false) repo io newio diffs =
+    let (ids, auths, rels, check) = Conex_diff.diffs_to_components diffs in
     let checksums = M.fold (fun _name versions acc -> S.union versions acc) check S.empty in
     L.debug (fun m -> m "verifying a diff with %d ids %d auths %d rels %d checks"
                 (S.cardinal ids) (S.cardinal auths) (S.cardinal rels) (S.cardinal checksums)) ;
-    (* all public keys of janitors in repo are valid. *)
-    verify_janitors ~valid:(fun _ _ -> true) io repo >>= fun repo ->
-    let janitor_keys =
-      S.fold (fun id acc ->
-          match IO.read_author io id with
-          | Ok idx -> List.map (fun (k,_) -> C.keyid id k) idx.Author.keys @ acc
-          | Error _ -> acc)
-        (match find_team repo "janitors" with None -> S.empty | Some x -> x)
-        []
-    in
     (* load all those janitors in newrepo which are valid (and verify janitors team) *)
-    let valid _id key = List.exists (fun k -> Digest.equal k key) janitor_keys in
     let fresh_repo = repository ~quorum:(quorum repo) (digestf repo) () in
     verify_janitors ~valid newio fresh_repo >>= fun newrepo ->
     (* now we do a full verification of the new repository *)
@@ -244,10 +243,4 @@ module Make (L : LOGS) (C : Conex_verify.S) = struct
         | Error _, Error _ -> maybe_m (monoton_checksums repo))
       () checksums >>= fun () ->
     Ok newrepo
-
-  let verify_diff ?ignore_missing io repo data =
-    let diffs = Conex_diff.to_diffs data in
-    let comp = Conex_diff.diffs_to_components diffs in
-    let newio = List.fold_left Conex_diff_provider.apply io diffs in
-    verify_patch ?ignore_missing repo io newio comp
 end

--- a/src/conex.mli
+++ b/src/conex.mli
@@ -51,13 +51,20 @@ module Make (L : LOGS) (C : Conex_verify.S): sig
   val verify_package : ?ignore_missing:bool -> Conex_io.t -> Conex_repository.t -> name ->
     (Conex_repository.t, string) result
 
-  (** [verify_diff ~ignore_missing io repository patch] first parses the [patch]
-      and applies it.  The key fingerprints ofjanitors in [repository] are used
-      to validate the janitors team of the repository with applied [patch].  All
-      identifiers and packages of the repository with [patch] applied are
-      verified, and additionally all modified resources have their monotonicity
-      verified.  If [ignore_missing] is true, packages with missing
-      authorisations and package indexes are ignored. *)
-  val verify_diff : ?ignore_missing:bool -> Conex_io.t -> Conex_repository.t -> string ->
+  (** [verify_snapshot io repo] reads and verifies the "snapshot", and verifies
+      that all other authors (and no additional authors) are present, and the
+      checksums match. *)
+  val verify_snapshot : Conex_io.t -> Conex_repository.t -> (unit, string) result
+
+  (** [verify_patch ~ignore_missing ~valid repo io newio diffs] verifies a
+      patch: [valid] is used to validate the janitors team of the repository
+      with applied patch [newio].  All identifiers and packages of the
+      repository with [patch] applied are verified, and additionally all
+      modified resources have their monotonicity verified.  If [ignore_missing]
+      is true, packages with missing authorisations and package indexes are
+      ignored. *)
+  val verify_patch : ?ignore_missing:bool ->
+    ?valid:(identifier -> Digest.t -> bool) -> Conex_repository.t ->
+    Conex_io.t -> Conex_io.t -> Conex_diff.t list ->
     (Conex_repository.t, string) result
 end

--- a/src/conex_diff_provider.ml
+++ b/src/conex_diff_provider.ml
@@ -47,3 +47,7 @@ let apply provider diff =
   and description = "Patch provider"
   in
   { basedir ; description ; file_type ; read ; write ; read_dir ; exists }
+
+let apply_diff io data =
+    let diffs = Conex_diff.to_diffs data in
+    (List.fold_left apply io diffs, diffs)

--- a/src/conex_diff_provider.mli
+++ b/src/conex_diff_provider.mli
@@ -1,4 +1,5 @@
-(** Data provider using an existing and a diff *)
-
+(** Data provider using an existing provider and a diff *)
 
 val apply : Conex_io.t -> Conex_diff.t -> Conex_io.t
+
+val apply_diff : Conex_io.t -> string -> (Conex_io.t * Conex_diff.t list)

--- a/src/conex_repository.ml
+++ b/src/conex_repository.ml
@@ -65,10 +65,7 @@ let add_valid_resource id repo res =
     Ok ({ repo with valid = M.add dgst_str (res.rname, res.rtyp, S.singleton id) t})
 
 let add_index repo idx =
-  foldM
-    (add_valid_resource idx.Author.name)
-    repo
-    idx.Author.resources
+  foldM (add_valid_resource idx.Author.name) repo idx.Author.resources
 
 let add_team repo team =
   { repo with teams = M.add team.Team.name team.Team.members repo.teams  }
@@ -76,8 +73,12 @@ let add_team repo team =
 (*BISECT-IGNORE-BEGIN*)
 let pp_ok ppf = function
   | `Approved id -> Format.fprintf ppf "ok by id %s" id
-  | `Both (id, js) -> Format.fprintf ppf "ok by id %s and quorum %s" id (String.concat ", " (S.elements js))
-  | `Quorum js -> Format.fprintf ppf "ok by quorum %s" (String.concat ", " (S.elements js))
+  | `Both (id, js) ->
+    let janitors = String.concat ", " (S.elements js) in
+    Format.fprintf ppf "ok by id %s and quorum %s" id janitors
+  | `Quorum js ->
+    let janitors = String.concat ", " (S.elements js) in
+    Format.fprintf ppf "ok by quorum %s" janitors
 (*BISECT-IGNORE-END*)
 
 type base_error = [

--- a/src/conex_repository.mli
+++ b/src/conex_repository.mli
@@ -180,6 +180,9 @@ val validate_checksums : t -> ?on_disk:Checksums.t -> Authorisation.t -> Release
    | `NotInReleases of name * S.t
    | `ChecksumsDiff of name * name list * name list * (Checksums.c * Checksums.c) list ]) result
 
+(** [validate_snapshot repo authors snap] validates [snap] with [authors] data. *)
+val validate_snapshot : t -> Author.t list -> Author.t -> (unit, string) result
+
 (** {1 Monotonicity} *)
 
 (** The variant of monotonicity errors. *)

--- a/src/conex_resource.ml
+++ b/src/conex_resource.ml
@@ -380,7 +380,8 @@ module Author = struct
   let resource_of_wire data =
     let open Wire in
     pmap data >>= fun map ->
-    Header.keys ~header:false ["index" ; "name" ; "typ" ; "digest" ] map >>= fun () ->
+    let keys = ["index" ; "name" ; "typ" ; "digest" ] in
+    Header.keys ~header:false keys map >>= fun () ->
     opt_err (search map "index") >>= pint >>= fun index ->
     opt_err (search map "name") >>= pdata >>= fun rname ->
     opt_err (search map "typ") >>= typ_of_wire >>= fun rtyp ->
@@ -403,10 +404,7 @@ module Author = struct
   (*BISECT-IGNORE-BEGIN*)
   let pp_r ppf { index ; rname ; rtyp ; digest } =
     Format.fprintf ppf "%a #%s %a@ %a"
-      pp_typ rtyp
-      (Uint.decimal index)
-      pp_name rname
-      Digest.pp digest
+      pp_typ rtyp (Uint.decimal index) pp_name rname Digest.pp digest
   (*BISECT-IGNORE-END*)
 
   type email = identifier

--- a/src/conex_utils.ml
+++ b/src/conex_utils.ml
@@ -14,6 +14,10 @@ let rec foldM f n = function
   | [] -> Ok n
   | x::xs -> f n x >>= fun n' -> foldM f n' xs
 
+let rec iterM f = function
+  | [] -> Ok ()
+  | x::xs -> f x >>= fun () -> iterM f xs
+
 let foldS f a s =
   S.fold (fun id r ->
       r >>= fun r ->

--- a/src/conex_utils.mli
+++ b/src/conex_utils.mli
@@ -28,6 +28,10 @@ val guard : bool -> 'a -> (unit, 'a) result
     the produced value, or [Error]. *)
 val foldM : ('a -> 'b -> ('a, 'c) result) -> 'a -> 'b list -> ('a, 'c) result
 
+(** [iterM f xs] applies [f] to each element of [xs], returns either [Ok] and
+    the produced value, or [Error]. *)
+val iterM : ('a -> (unit, 'b) result) -> 'a list -> (unit, 'b) result
+
 (** [foldS f a s] applies [f] to each element of the set [s], returns either
     [Ok] and the produced value, or [Error]. *)
 val foldS : ('a -> string -> ('a, 'c) result) -> 'a -> S.t -> ('a, 'c) result


### PR DESCRIPTION
this implements a snapshot service, which approves all other authors.  it also let's `conex_verify_*` first verify the `snapshot` (identifier and data) before continuing on verifying individual authors.  note that janitors still are verified first, in order to verify that the snapshot public key is approved by (a quorum of) janitors.  the janitors are included in the snapshot -- it doesn't really really matter in which order snapshot vs janitors are verified.