### PR TITLE
Fix patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
-sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+services:
+  - docker
+sudo: false
 env:
   global:
+    - DISTRO="alpine"
     - PINS="conex:. conex-nocrypto:."
   matrix:
-    - OCAML_VERSION=4.03 PACKAGE="conex" TESTS=false
-    - OCAML_VERSION=4.04 PACKAGE="conex-nocrypto"
     - OCAML_VERSION=4.05 PACKAGE="conex" TESTS=false
     - OCAML_VERSION=4.06 PACKAGE="conex-nocrypto"
     - OCAML_VERSION=4.07 PACKAGE="conex" TESTS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ env:
     - PINS="conex:. conex-nocrypto:."
   matrix:
     - OCAML_VERSION=4.03 PACKAGE="conex" TESTS=false
-    - OCAML_VERSION=4.05 PACKAGE="conex" TESTS=false
     - OCAML_VERSION=4.04 PACKAGE="conex-nocrypto"
+    - OCAML_VERSION=4.05 PACKAGE="conex" TESTS=false
     - OCAML_VERSION=4.06 PACKAGE="conex-nocrypto"
+    - OCAML_VERSION=4.07 PACKAGE="conex" TESTS=false
+    - OCAML_VERSION=4.08 PACKAGE="conex-nocrypto"
+    - OCAML_VERSION=4.09 PACKAGE="conex" TESTS=false
 notifications:
   email: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## 0.11.0 (2019-12-21)
+
+* Adapt to X509 0.7.0 API
+* Avoid deprecation warnings by using stdlib-shims
+* Adjust opam repository file locations #13, now the whitelist is:
+  packages/NV/opam and packages/NV/files/*
+  where NV is either name.version or name/name.version
+* Various fixes for diff in the real world #13
+
 ## 0.10.1 (2018-09-08)
 
 * re-add LICENSE.md file (with a 2 clause BSD license)

--- a/app/conex_verify_openssl.ml
+++ b/app/conex_verify_openssl.ml
@@ -75,7 +75,7 @@ let terminal () =
   let dumb = try Sys.getenv "TERM" = "dumb" with
     | Not_found -> true
   in
-  let isatty = try Unix.(isatty (descr_of_out_channel Pervasives.stdout)) with
+  let isatty = try Unix.(isatty (descr_of_out_channel Stdlib.stdout)) with
     | Unix.Unix_error _ -> false
   in
   if not dumb && isatty then `Ansi_tty else `None

--- a/app/dune
+++ b/app/dune
@@ -9,7 +9,7 @@
   (public_name conex_verify_openssl)
   (package conex)
   (modules conex_verify_openssl)
-  (libraries cmdliner conex conex.openssl conex.unix conex_cmd))
+  (libraries cmdliner conex conex.openssl conex.unix conex_cmd stdlib-shims))
 
 (executable
   (name conex_verify_nocrypto)

--- a/conex-nocrypto.opam
+++ b/conex-nocrypto.opam
@@ -6,8 +6,8 @@ homepage: "https://github.com/hannesm/conex"
 doc: "https://hannesm.github.io/conex/doc"
 bug-reports: "https://github.com/hannesm/conex/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "ocaml" {>= "4.05.0"}
+  "dune"
   "alcotest" {with-test}
   "cmdliner"
   "conex" {= version}

--- a/conex.opam
+++ b/conex.opam
@@ -6,8 +6,8 @@ homepage: "https://github.com/hannesm/conex"
 doc: "https://hannesm.github.io/conex/doc"
 bug-reports: "https://github.com/hannesm/conex/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "ocaml" {>= "4.05.0"}
+  "dune"
   "cmdliner"
   "opam-file-format" {>= "2.0.0~rc2"}
   "stdlib-shims"

--- a/conex.opam
+++ b/conex.opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {build}
   "cmdliner"
   "opam-file-format" {>= "2.0.0~rc2"}
+  "stdlib-shims"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/conex_diff.ml
+++ b/src/conex_diff.ml
@@ -154,7 +154,7 @@ let to_diffs data =
     | xs ->
       (* TODO is this a good idea here to drop potential errors? *)
       match to_diff xs with
-      | None -> acc
+      | None -> List.rev acc
       | Some (diff, rest) -> doit (diff :: acc) rest
   in
   doit [] lines

--- a/src/conex_diff.ml
+++ b/src/conex_diff.ml
@@ -67,6 +67,8 @@ let count_to_sl_sl data =
 let sort_into_bags dir mine their m_nl t_nl str =
   if String.length str = 0 then
     None
+  else if String.is_prefix ~prefix:"---" str then
+    None
   else match String.get str 0, String.slice ~start:1 str with
     | ' ', data -> Some (`Both, (data :: mine), (data :: their), m_nl, t_nl)
     | '+', data -> Some (`Their, mine, (data :: their), m_nl, t_nl)

--- a/src/conex_diff.mli
+++ b/src/conex_diff.mli
@@ -2,21 +2,23 @@ open Conex_utils
 
 (** Diff: decode patch files into hunks. *)
 
-(** A hunk. *)
+(** A hunk *)
 type hunk
+
+val pp_hunk : Format.formatter -> hunk -> unit
 
 type operation =
   | Edit of string
   | Rename of string * string
   | Delete of string
   | Create of string
+  | Rename_only of string * string
 
-val pp_operation : Format.formatter -> operation -> unit
+val pp_operation : git:bool -> Format.formatter -> operation -> unit
 
 val operation_eq : operation -> operation -> bool
 
-(** A diff is a list of hunks, and a filename (mine and their are different for
-    file addition and removal, otherwise they should be equal. *)
+(** A diff is a list of hunks, and an operation. *)
 type t = {
   operation : operation ;
   hunks : hunk list ;
@@ -24,15 +26,15 @@ type t = {
   their_no_nl : bool ;
 }
 
-val pp : Format.formatter -> t -> unit
+val pp : git:bool -> Format.formatter -> t -> unit
 
 (** [to_diffs str] decodes the given patch into a list of [diff]. *)
 val to_diffs : string -> t list
 
+(** [patch data diff] is [data'], which is the result of applying [diff] to
+    [data]. If [data'] is [None], it was deleted. *)
+val patch : string option -> t -> string option
+
 (** [ids rootname keydir diffs] returns whether the root file was changed, and
     the set of modified ids. *)
 val ids : string -> path -> t list -> (bool * S.t, string) result
-
-(** [patch data diff] is [data'], which is the result of applying [diff] to
-    [data]. *)
-val patch : string option -> t -> string

--- a/src/conex_diff.mli
+++ b/src/conex_diff.mli
@@ -8,15 +8,18 @@ type hunk
 (** A diff is a list of hunks, and a filename (mine and their are different for
     file addition and removal, otherwise they should be equal. *)
 type t = {
-  mine_name : string ;
-  their_name : string ;
+  mine_name : string option ;
+  their_name : string option ;
   hunks : hunk list ;
+  mine_no_nl : bool ;
+  their_no_nl : bool ;
 }
 
-(** [file diff] is [mine_name] unless this is "/dev/null", in which case
-    [their_name] is used.  A potentially leading "a/" or "b/" is stripped from
-    mine/their. *)
-val file : t -> string
+val pp : Format.formatter -> t -> unit
+
+(** [filename name] strips potentially leading "a/" or "b/" from given [name].
+    If [name] is /dev/null, [None] is returned! *)
+val filename : string -> string option
 
 (** [to_diffs str] decodes the given patch into a list of [diff]. *)
 val to_diffs : string -> t list

--- a/src/conex_diff.mli
+++ b/src/conex_diff.mli
@@ -5,21 +5,26 @@ open Conex_utils
 (** A hunk. *)
 type hunk
 
+type operation =
+  | Edit of string
+  | Rename of string * string
+  | Delete of string
+  | Create of string
+
+val pp_operation : Format.formatter -> operation -> unit
+
+val operation_eq : operation -> operation -> bool
+
 (** A diff is a list of hunks, and a filename (mine and their are different for
     file addition and removal, otherwise they should be equal. *)
 type t = {
-  mine_name : string option ;
-  their_name : string option ;
+  operation : operation ;
   hunks : hunk list ;
   mine_no_nl : bool ;
   their_no_nl : bool ;
 }
 
 val pp : Format.formatter -> t -> unit
-
-(** [filename name] strips potentially leading "a/" or "b/" from given [name].
-    If [name] is /dev/null, [None] is returned! *)
-val filename : string -> string option
 
 (** [to_diffs str] decodes the given patch into a list of [diff]. *)
 val to_diffs : string -> t list

--- a/src/conex_diff_provider.ml
+++ b/src/conex_diff_provider.ml
@@ -49,7 +49,7 @@ let apply provider diff =
     | Some p when p = pn -> Ok File
     | Some p when String.is_prefix ~prefix:(pn ^ "/") p -> Ok Directory
     | t -> match t, diff.mine_name with
-      | None, Some p when p = pn -> Error "does not exist"
+      | _, Some p when p = pn -> Error "does not exist"
       | _ -> provider.file_type path
   and read_dir path =
     let rec strip parent x = match parent, x with
@@ -72,8 +72,8 @@ let apply provider diff =
       match diff.mine_name, diff.their_name with
       | Some p, Some p' when p = p' -> None, None
       | Some p, Some p' ->
-        (if String.is_prefix ~prefix p then dropped_pre p else None),
-        (if String.is_prefix ~prefix p' then dropped_pre p' else None)
+        (if String.is_prefix ~prefix p' then dropped_pre p' else None),
+        (if String.is_prefix ~prefix p then dropped_pre p else None)
       | None, Some p' ->
         (if String.is_prefix ~prefix p' then dropped_pre p' else None), None
       | Some p, None ->
@@ -96,7 +96,7 @@ let apply provider diff =
     match diff.their_name with
     | Some p when p = pn -> true
     | t -> match t, diff.mine_name with
-      | None, Some p when p = pn -> false
+      | _, Some p when p = pn -> false
       | _ -> provider.exists path
   and basedir = provider.basedir
   and description = "Patch provider"

--- a/src/conex_diff_provider.ml
+++ b/src/conex_diff_provider.ml
@@ -2,60 +2,107 @@ open Conex_utils
 open Conex_io
 open Conex_diff
 
+(* this a very basic implementation, far from being general:
+   - only a single (well-formed) patch file is used for creating a diff provider
+
+this implies the invariant that for each path p, there exists at most one
+  matching diff (multiple kinds are possible:
+- edited
+ --- p
+ +++ p
+- removed
+ --- p
+ +++ /dev/null
+- created
+ --- /dev/null
+ +++ p
+- renamed
+ --- p2
+ +++ p
+
+TODO: what happens if p2 now becomes a directory?
+
+so for any incoming path p, there are four functions to support:
+- exists: if theirs = p then true, if mine = p (&& not theirs p) then false
+- file_type: if theirs = p then Ok file, p^"/" 'is a prefix of' theirs then Ok directory
+- read: if theirs = p then read_old (if none, no) and apply patch
+- read_dir: edit and created are trivial, remove and rename are tricky!
+*)
 let apply provider diff =
   let read path =
-    if file diff = path_to_string path then
-      match provider.read path with
-      | Ok data -> Ok (patch (Some data) diff)
-      | Error _ -> Ok (patch None diff)
-    else
-      provider.read path
+    let pn = path_to_string path in
+    match diff.their_name with
+    | Some p when p = pn ->
+      let old = match diff.mine_name with
+        | None -> None
+        | Some p -> match provider.read (string_to_path_exn p) with
+          | Ok data -> Some data
+          | Error _ -> None
+      in
+      Ok (patch old diff)
+    | _ -> match diff.mine_name with
+      | Some p when p = pn -> Error "does not exist anymore"
+      | _ -> provider.read path
   and file_type path =
-    let pn = path_to_string path
-    and name = file diff
-    in
-    if pn = name then
-      Ok File
-    else if Conex_utils.String.is_prefix ~prefix:(pn ^ "/") name then
-      Ok Directory
-    else
-      provider.file_type path
+    let pn = path_to_string path in
+    match diff.their_name with
+    | Some p when p = pn -> Ok File
+    | Some p when String.is_prefix ~prefix:(pn ^ "/") p -> Ok Directory
+    | t -> match t, diff.mine_name with
+      | None, Some p when p = pn -> Error "does not exist"
+      | _ -> provider.file_type path
   and read_dir path =
     let rec strip parent x = match parent, x with
       | [], xs -> Some xs
       | hd::tl, hd'::tl' when hd = hd' -> strip tl tl'
       | _ -> None
     in
-    let local =
-      match string_to_path (file diff) with
-      | Ok p ->
-        begin match strip path p with
+    let local_add, local_remove =
+      let prefix = path_to_string path in
+      let dropped_pre p =
+        match string_to_path p with
+        | Error _ -> None
+        | Ok p ->
+          match strip path p with
           | None -> None
           | Some [] -> None
           | Some [ x ] -> Some (File, x)
           | Some (x::_) -> Some (Directory, x)
-        end
-      | Error _ -> None
+      in
+      match diff.mine_name, diff.their_name with
+      | Some p, Some p' when p = p' -> None, None
+      | Some p, Some p' ->
+        (if String.is_prefix ~prefix p then dropped_pre p else None),
+        (if String.is_prefix ~prefix p' then dropped_pre p' else None)
+      | None, Some p' ->
+        (if String.is_prefix ~prefix p' then dropped_pre p' else None), None
+      | Some p, None ->
+        None, (if String.is_prefix ~prefix p then dropped_pre p else None)
+      | None, None -> assert false
     in
-    match provider.read_dir path, local with
-      | Ok files, Some data -> Ok (data :: files)
-      | Ok files, None -> Ok files
-      | Error _, Some data -> Ok [data]
-      | Error e, None -> Error e
+    let f ys =
+      match local_remove with
+      | None -> ys
+      | Some remove -> List.filter (fun x -> not (remove = x)) ys
+    in
+    match provider.read_dir path, local_add with
+    | Ok files, Some add -> Ok (f (add :: files))
+    | Ok files, None -> Ok (f files)
+    | Error _, Some add -> Ok [add]
+    | Error e, None -> Error e
   and write _ _ = Error "read only"
   and exists path =
-    let pn = path_to_string path
-    and name = file diff
-    in
-    if pn = name then
-      true
-    else
-      provider.exists path
+    let pn = path_to_string path in
+    match diff.their_name with
+    | Some p when p = pn -> true
+    | t -> match t, diff.mine_name with
+      | None, Some p when p = pn -> false
+      | _ -> provider.exists path
   and basedir = provider.basedir
   and description = "Patch provider"
   in
   { basedir ; description ; file_type ; read ; write ; read_dir ; exists }
 
 let apply_diff io data =
-    let diffs = Conex_diff.to_diffs data in
-    (List.fold_left apply io diffs, diffs)
+  let diffs = Conex_diff.to_diffs data in
+  List.fold_left apply io diffs, diffs

--- a/src/conex_diff_provider.ml
+++ b/src/conex_diff_provider.ml
@@ -5,82 +5,88 @@ open Conex_diff
 (* this a very basic implementation, far from being general:
    - only a single (well-formed) patch file is used for creating a diff provider
 *)
-let apply provider diff =
+let target = function
+  | Edit name
+  | Rename (_, name)
+  | Rename_only (_, name)
+  | Create name -> Some name
+  | Delete _ -> None
+
+let source = function
+  | Rename (old, _) | Rename_only (old, _) | Delete old | Edit old -> Some old
+  | _ -> None
+
+module FS = Set.Make(struct
+    type t = file_type * string
+    let compare (t, v) (t', v') = match t, t' with
+      | File, File | Directory, Directory -> String.compare v v'
+      | File, Directory -> 1 | Directory, File -> -1
+  end)
+
+let apply provider diffs =
+  let find_diff f path =
+    List.find_opt (fun x ->
+        match f x.operation with
+        | None -> false
+        | Some path' -> path_equal (string_to_path_exn path') path)
+      diffs
+  in
   let read path =
-    let pn = path_to_string path in
-    let opt_read p = match provider.read (string_to_path_exn p) with
-      | Ok data -> Some data
-      | Error _ -> None
-    in
-    match diff.operation with
-    | Delete p when p = pn -> Error "does not exist anymore (deleted)"
-    | Create p when p = pn -> Ok (patch None diff)
-    | Edit p when p = pn -> Ok (patch (opt_read p) diff)
-    | Rename (previous, p) when p = pn -> Ok (patch (opt_read previous) diff)
-    | Rename (p, _) when p = pn -> Error "does not exist anymore (renamed)"
-    | _ -> provider.read path
+    match find_diff target path, find_diff source path with
+    | None, None -> provider.read path
+    | None, Some _ -> Error "no data"
+    | Some diff, _ ->
+      let res_patch old = match patch old diff with
+        | None -> Error "no data"
+        | Some data -> Ok data
+      in
+      match source diff.operation with
+      | None -> res_patch None
+      | Some x -> match provider.read (string_to_path_exn x) with
+        | Error x -> Error x
+        | Ok data -> res_patch (Some data)
   and file_type path =
-    let pn = path_to_string path in
-    match diff.operation with
-    | Delete p when p = pn -> Error "does not exist anymore (deleted)"
-    | Create p when p = pn -> Ok File
-    | Edit p when p = pn -> Ok File
-    | Rename (_, p) when p = pn -> Ok File
-    | Rename (p, _) when p = pn -> Error "does not exist anymore (renamed)"
-    | _ -> provider.file_type path
+    match find_diff target path, find_diff source path with
+    | None, None -> provider.file_type path
+    | None, Some _ -> Error "does not exist anymore (deleted)"
+    | Some _, _ -> Ok File
   and read_dir path =
-    let rec strip parent x = match parent, x with
-      | [], xs -> Some xs
-      | hd::tl, hd'::tl' when hd = hd' -> strip tl tl'
-      | _ -> None
+    (* this results in some empty directories which are not present on disk *)
+    (* the reason is that I get the old files and directories,
+       I also know the diffs (i.e. added and removed and renamed files), but
+       for inspecting whether a directory is empty (i.e. all files are removed),
+       I'd need the whole subdir information (prune empty ones) *)
+    let old = match provider.read_dir path with
+      | Ok files -> FS.of_list files
+      | Error _ -> FS.empty
     in
-    let dropped_pre p =
-      match string_to_path p with
-      | Error _ -> None
-      | Ok p ->
-        match strip path p with
-        | None -> None
-        | Some [] -> None
-        | Some [ x ] -> Some (File, x)
-        | Some (x::_) -> Some (Directory, x)
+    let drop_pre dir path' =
+      let rec dropit a b = match a, b with
+        | [], [ x ] -> Some (File, x)
+        | [], x::_ -> if dir then Some (Directory, x) else None
+        | x::xs, y::ys when String.equal x y -> dropit xs ys
+        | _ -> None
+      in
+      dropit path (string_to_path_exn path')
+    and opt_add x xs = match x with None -> xs | Some x -> FS.add x xs
+    and opt_rem x xs = match x with None -> xs | Some x -> FS.remove x xs
     in
-    let other = match provider.read_dir path with
-      | Ok files -> files
-      | Error _ -> []
+    let stuff =
+      List.fold_left (fun acc d ->
+          match d.operation with
+          | Create name | Edit name -> opt_add (drop_pre true name) acc
+          | Rename (old, name) | Rename_only (old, name) ->
+            opt_rem (drop_pre false old) (opt_add (drop_pre true name) acc)
+          | Delete old -> opt_rem (drop_pre false old) acc)
+        old diffs
     in
-    let prefix = path_to_string path in
-    let without o = function
-      | None -> o
-      | Some x -> List.filter (fun y -> not (y = x)) o
-    and add o = function
-      | None -> o
-      | Some x -> x :: o
-    in
-    let r = match diff.operation with
-      | Delete p when String.is_prefix ~prefix p -> without other (dropped_pre p)
-      | Create p when String.is_prefix ~prefix p -> add other (dropped_pre p)
-      | Edit _ -> other
-      | Rename (o, n) ->
-        let o' =
-          if String.is_prefix ~prefix o then
-            without other (dropped_pre o)
-          else
-            other
-        in
-        if String.is_prefix ~prefix n then add o' (dropped_pre n) else o'
-      | _ -> other
-    in
-    if r = [] then Error "empty" else Ok r
+    Ok (FS.elements stuff)
   and write _ _ = Error "read only"
   and exists path =
-    let pn = path_to_string path in
-    match diff.operation with
-    | Delete p when p = pn -> false
-    | Create p when p = pn -> true
-    | Edit p when p = pn -> true
-    | Rename (_, p) when p = pn -> true
-    | Rename (p, _) when p = pn -> false
-    | _ -> provider.exists path
+    match find_diff target path, find_diff source path with
+    | None, None -> provider.exists path
+    | Some _, _ -> true
+    | None, Some _ -> false
   and basedir = provider.basedir
   and description = "Patch provider"
   in
@@ -88,4 +94,4 @@ let apply provider diff =
 
 let apply_diff io data =
   let diffs = Conex_diff.to_diffs data in
-  List.fold_left apply io diffs, diffs
+  apply io diffs, diffs

--- a/src/conex_diff_provider.mli
+++ b/src/conex_diff_provider.mli
@@ -1,5 +1,5 @@
 (** Data provider using an existing provider and a diff *)
 
-val apply : Conex_io.t -> Conex_diff.t -> Conex_io.t
+val apply : Conex_io.t -> Conex_diff.t list -> Conex_io.t
 
 val apply_diff : Conex_io.t -> string -> (Conex_io.t * Conex_diff.t list)

--- a/src/conex_io.ml
+++ b/src/conex_io.ml
@@ -72,7 +72,7 @@ let read_targets t root opam id =
         (`NameMismatch (`Targets, id, targets.Targets.name)) >>= fun () ->
       let check_path t =
         if opam then
-          guard (Target.valid_path t) (`InvalidPath (id, t.Target.filename))
+          guard (Target.valid_opam_path t) (`InvalidPath (id, t.Target.filename))
         else
           Ok ()
       in
@@ -104,7 +104,7 @@ let compute_checksum ?(prefix = [ "packages" ]) t opam f path =
       let filename = prefix @ [ name ] in
       t.read filename >>= fun data ->
       let target = target f (otherp @ [ name ]) data in
-      if not opam || opam && Target.valid_path target then
+      if not opam || opam && Target.valid_opam_path target then
         Ok (target :: acc)
       else
         Error ("invalid path " ^ path_to_string filename)

--- a/src/conex_resource.ml
+++ b/src/conex_resource.ml
@@ -757,12 +757,16 @@ module Target = struct
       (pp_list Digest.pp) t.digest
   (*BISECT-IGNORE-END*)
 
-  let valid_path t =
+  let valid_opam_path t =
     (* this is an opam repository side condition:
-       [ foo ; foo.version ; .. ] *)
+       [ foo ; foo.version ; opam ]
+       [ foo ; foo.version ; files ; _ ]
+       or [ foo.version ; opam ] [ foo.version ; files ; _ ] *)
     match t.filename with
-      | pname :: pversion :: _ -> String.is_prefix ~prefix:(pname ^ ".") pversion
-      | _ -> false
+    | [ pname ; pversion ; "opam" ] | [ pname ; pversion ; "files" ; _ ] ->
+      String.is_prefix ~prefix:(pname ^ ".") pversion
+    | [ _ ; "opam" ] | [ _ ; "files" ; _ ] -> true
+    | _ -> false
 
   let of_wire wire =
     let open Wire in

--- a/src/conex_resource.mli
+++ b/src/conex_resource.mli
@@ -340,9 +340,8 @@ module Target : sig
   val equal : t -> t -> bool
 
   (** [valid_path t] is [true] if the filename sticks to opam repository rules:
-     [foo/foo.version/xx] (may not be [foo/bar.version], otherwise treat as
-     [bar] package) *)
-  val valid_path : t -> bool
+     [foo/foo.version/opam] of [foo.version/opam]. *)
+  val valid_opam_path : t -> bool
 
   (** [pp] is a pretty printer for a target. *)
   val pp : t fmt

--- a/src/conex_utils.ml
+++ b/src/conex_utils.ml
@@ -66,12 +66,9 @@ module String = struct
 
   let cuts sep str =
     let rec doit acc s =
-      if String.length s = 0 then
-        List.rev acc
-      else
-        match cut sep s with
-        | None -> List.rev (s :: acc)
-        | Some (a, b) -> doit (a :: acc) b
+      match cut sep s with
+      | None -> List.rev (s :: acc)
+      | Some (a, b) -> doit (a :: acc) b
     in
     doit [] str
 

--- a/src/conex_utils.ml
+++ b/src/conex_utils.ml
@@ -133,6 +133,8 @@ module String = struct
 
   let compare_insensitive a b =
     compare (to_lower a) (to_lower b)
+
+  let equal = String.equal
 end
 
 module Uint = struct

--- a/src/conex_utils.mli
+++ b/src/conex_utils.mli
@@ -128,6 +128,9 @@ module String : sig
   (** [compare_insensitive a b] first converts [a] and [b] to lowercase strings,
       then uses [compare]. *)
   val compare_insensitive : t -> t -> int
+
+  (** [equal a b] is [String.equal a b]. *)
+  val equal : t -> t -> bool
 end
 
 (** {1 Unsigned integers} *)

--- a/test/dune
+++ b/test/dune
@@ -1,8 +1,4 @@
-(executables
-  (names tests)
-  (libraries conex conex-nocrypto conex.openssl alcotest nocrypto.unix))
-
-(alias
-  (name runtest)
+(test
+  (name tests)
   (package conex-nocrypto)
-  (action (run ./tests.exe)))
+  (libraries conex conex-nocrypto conex.openssl alcotest nocrypto.unix))

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -302,7 +302,7 @@ let diff_test_complex () =
   in
   let d, _diffs = Conex_diff_provider.apply_diff p diff in
   Alcotest.check (result (Alcotest.list it) str_err) __LOC__
-    (Ok [ File, "bar" ; File, "baz" ; File, "staying" ; File, "foobarbaz" ])
+    (Ok [ File, "baz" ; File, "bar" ; File, "staying" ; File, "foobarbaz" ])
     (d.read_dir ["packages"]) ;
   Alcotest.check Alcotest.bool __LOC__ false (d.exists ["packages" ; "foo"]) ;
   Alcotest.check Alcotest.bool __LOC__ false (d.exists ["packages" ; "foobar"]) ;

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -198,7 +198,7 @@ let diff_test_remove () =
   Alcotest.check Alcotest.bool __LOC__
     false (d.exists ["packages" ; "foo"]) ;
   Alcotest.check (result (Alcotest.list it) str_err) __LOC__
-    (Ok [ ]) (d.read_dir ["packages"]) ;
+    (Error "") (d.read_dir ["packages"]) ;
   Alcotest.check (result ft str_err) __LOC__
     (Error "") (d.file_type ["packages" ; "foo"]) ;
   Alcotest.check (result Alcotest.string str_err) __LOC__

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -180,11 +180,11 @@ let diff_test_create () =
   Alcotest.check (result ft str_err) __LOC__
     (Ok File) (d.file_type ["packages" ; "foo"]) ;
   Alcotest.check (result Alcotest.string str_err) __LOC__
-    (Ok "bar") (d.read ["packages" ; "foo"])
+    (Ok "bar\n") (d.read ["packages" ; "foo"])
 
 let diff_test_remove () =
   let p = Mem.mem_provider () in
-  (match p.write ["packages" ; "foo" ] "bar" with
+  (match p.write ["packages" ; "foo" ] "bar\n" with
    | Ok () -> ()
    | Error _ -> assert false) ;
   let diff = {|
@@ -198,7 +198,7 @@ let diff_test_remove () =
   Alcotest.check Alcotest.bool __LOC__
     false (d.exists ["packages" ; "foo"]) ;
   Alcotest.check (result (Alcotest.list it) str_err) __LOC__
-    (Error "") (d.read_dir ["packages"]) ;
+    (Ok []) (d.read_dir ["packages"]) ;
   Alcotest.check (result ft str_err) __LOC__
     (Error "") (d.file_type ["packages" ; "foo"]) ;
   Alcotest.check (result Alcotest.string str_err) __LOC__
@@ -206,7 +206,7 @@ let diff_test_remove () =
 
 let diff_test_rename () =
   let p = Mem.mem_provider () in
-  (match p.write ["packages" ; "foo" ] "bar" with
+  (match p.write ["packages" ; "foo" ] "bar\n" with
    | Ok () -> ()
    | Error _ -> assert false) ;
   let diff = {|
@@ -231,11 +231,11 @@ let diff_test_rename () =
   Alcotest.check (result Alcotest.string str_err) __LOC__
     (Error "") (d.read ["packages" ; "foo"]) ;
   Alcotest.check (result Alcotest.string str_err) __LOC__
-    (Ok "foobar") (d.read ["packages" ; "bar"])
+    (Ok "foobar\n") (d.read ["packages" ; "bar"])
 
 let diff_test_edit () =
   let p = Mem.mem_provider () in
-  (match p.write ["packages" ; "foo" ] "bar" with
+  (match p.write ["packages" ; "foo" ] "bar\n" with
    | Ok () -> ()
    | Error _ -> assert false) ;
   let diff = {|
@@ -260,20 +260,20 @@ let diff_test_edit () =
   Alcotest.check (result Alcotest.string str_err) __LOC__
     (Error "") (d.read ["packages" ; "bar"]) ;
   Alcotest.check (result Alcotest.string str_err) __LOC__
-    (Ok "foobar") (d.read ["packages" ; "foo"])
+    (Ok "foobar\n") (d.read ["packages" ; "foo"])
 
 let diff_test_complex () =
   let p = Mem.mem_provider () in
-  (match p.write ["packages" ; "foo" ] "bar" with
+  (match p.write ["packages" ; "foo" ] "bar\n" with
    | Ok () -> ()
    | Error _ -> assert false) ;
-  (match p.write ["packages" ; "foobar" ] "baz" with
+  (match p.write ["packages" ; "foobar" ] "baz\n" with
    | Ok () -> ()
    | Error _ -> assert false) ;
-  (match p.write ["packages" ; "foobarbaz" ] "foobarbaz" with
+  (match p.write ["packages" ; "foobarbaz" ] "foobarbaz\n" with
    | Ok () -> ()
    | Error _ -> assert false) ;
-  (match p.write ["packages" ; "staying" ] "data" with
+  (match p.write ["packages" ; "staying" ] "data\n" with
    | Ok () -> ()
    | Error _ -> assert false) ;
   Alcotest.check (result (Alcotest.list it) str_err) __LOC__
@@ -302,7 +302,7 @@ let diff_test_complex () =
   in
   let d, _diffs = Conex_diff_provider.apply_diff p diff in
   Alcotest.check (result (Alcotest.list it) str_err) __LOC__
-    (Ok [ File, "baz" ; File, "bar" ; File, "staying" ; File, "foobarbaz" ])
+    (Ok [ File, "bar" ; File, "baz" ; File, "foobarbaz" ; File, "staying" ])
     (d.read_dir ["packages"]) ;
   Alcotest.check Alcotest.bool __LOC__ false (d.exists ["packages" ; "foo"]) ;
   Alcotest.check Alcotest.bool __LOC__ false (d.exists ["packages" ; "foobar"]) ;
@@ -318,10 +318,10 @@ let diff_test_complex () =
   Alcotest.check (result ft str_err) __LOC__ (Ok File) (d.file_type ["packages" ; "bar"]) ;
   Alcotest.check (result Alcotest.string str_err) __LOC__ (Error "") (d.read ["packages" ; "foo"]) ;
   Alcotest.check (result Alcotest.string str_err) __LOC__ (Error "") (d.read ["packages" ; "foobar"]) ;
-  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "foobar") (d.read ["packages" ; "foobarbaz"]) ;
-  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "data") (d.read ["packages" ; "staying"]) ;
-  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "baz") (d.read ["packages" ; "baz"]) ;
-  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "foobar") (d.read ["packages" ; "bar"])
+  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "foobar\n") (d.read ["packages" ; "foobarbaz"]) ;
+  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "data\n") (d.read ["packages" ; "staying"]) ;
+  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "baz\n") (d.read ["packages" ; "baz"]) ;
+  Alcotest.check (result Alcotest.string str_err) __LOC__ (Ok "foobar\n") (d.read ["packages" ; "bar"])
 
 let tests = [
   "empty provider", `Quick, empty_p ;

--- a/test/test_string.ml
+++ b/test/test_string.ml
@@ -1,0 +1,31 @@
+
+(* String.concat "/" (String.cuts '/' xs) == xs *)
+let basic_cuts () =
+  let sep = '/'
+  and j = "/"
+  and data = ""
+  in
+  Alcotest.(check string __LOC__ data
+              (String.concat j (Conex_utils.String.cuts sep data)));
+  let data = "foo" in
+  Alcotest.(check string __LOC__ data
+              (String.concat j (Conex_utils.String.cuts sep data)));
+  let data = "///" in
+  Alcotest.(check string __LOC__ data
+              (String.concat j (Conex_utils.String.cuts sep data)));
+  let data = "foo/bar/baz" in
+  Alcotest.(check string __LOC__ data
+              (String.concat j (Conex_utils.String.cuts sep data)));
+  let data = "foo//bar///baz" in
+  Alcotest.(check string __LOC__ data
+              (String.concat j (Conex_utils.String.cuts sep data)));
+  let data = "/foo/bar/baz/" in
+  Alcotest.(check string __LOC__ data
+              (String.concat j (Conex_utils.String.cuts sep data)));
+  let data = "/foo//bar//baz/" in
+  Alcotest.(check string __LOC__ data
+              (String.concat j (Conex_utils.String.cuts sep data)))
+
+let tests = [
+  "basic cuts is good", `Quick, basic_cuts ;
+]

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -9,6 +9,7 @@ let () =
   in
   Alcotest.run "Conex tests" (
     ("Uint", Test_uint.tests) ::
+    ("String", Test_string.tests) ::
     ("Path", Test_path.tests) ::
     ("Tree", Test_tree.tests) ::
     ("provider", Test_provider.tests) ::

--- a/unix/conex_unix_provider.ml
+++ b/unix/conex_unix_provider.ml
@@ -29,7 +29,10 @@ let fs_provider basedir =
     file_type p
   and read path =
     let fn = get path in
-    read_file fn
+    Printf.printf "unix reading %s.." fn;
+    match read_file fn with
+    | Ok data -> Printf.printf "%d bytes\n" (String.length data); Ok data
+    | Error e -> Printf.printf "%s errored\n" e; Error e
   and write path data =
     ensure_dir path >>= fun () ->
     let nam = get path in


### PR DESCRIPTION
this adapts some no-new-at-end-of-file from hannesm/patch, and in addition adds some tests for the conex_diff_provider, which exposed even more bugs and fixes :)

it could for sure have some more (real-world, more complex) test cases to validate that conex_diff is now up for its job -- maybe separating opam-repo into a series of diffs and applying them -- checking at each step that the on-disk thing matches conex_diff view of it would be good -- i.e. some shell script calling to git and conex.